### PR TITLE
Migrate to bitmap-based physical memory management

### DIFF
--- a/include/kernel/idt.h
+++ b/include/kernel/idt.h
@@ -35,5 +35,6 @@ typedef struct __attribute__ ((packed)) {
 typedef void (*irq_handler_t) (registers_t*);
 
 void __init_idt__ (void);
+void idt_register_handler (int vector, irq_handler_t handler);
 
 #endif

--- a/src/kernel/memmap.c
+++ b/src/kernel/memmap.c
@@ -1,9 +1,0 @@
-#include <kernel/memmgt.h>
-#include <stddef.h>
-#include <stdint.h>
-
-__attribute__ ((section (".memory_map"), aligned (0x1000))) struct {
-	pdpt_entry_t pdpt_entry[512];
-	pd_entry_t pd_entry[512];
-	pt_entry_t pt_entry[512];
-} memmap;

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -253,51 +253,31 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 	// set up bitmap for physical page allocation
 	init_physical_bitmap (memmap_response);
 
-	// set up default memory map
-	memset (&memmap, 0, sizeof (memmap));
-
-	for (int i = 0; i < 1; i++) {
-		memmap.pdpt_entry[i].present = 1;
-		memmap.pdpt_entry[i].read_write = 1;
-		memmap.pdpt_entry[i].pd_base_address =
-			((uint64_t)(get_paddr (&memmap.pd_entry[i * 512])) >> 12) & 0xFFFFFFFFFF;
-		memmap.pdpt_entry[i].xd = 1;
-	}
-
-	for (int i = 0; i < 1; i++) {
-		memmap.pd_entry[i].present = 1;
-		memmap.pd_entry[i].rw = 1;
-		memmap.pd_entry[i].nex = 1;
-		memmap.pd_entry[i].pt_base_address =
-			((uint64_t)(get_paddr (&memmap.pt_entry[i * 512])) >> 12) & 0xFFFFFFFFFF;
-	}
-
+	paddr_t phys_tables = alloc_ppages (3);
 	paddr_t initial_frames = alloc_ppages (512);
 
+	pdpt_entry_t* pdpt = (pdpt_entry_t*) get_vaddr_from_frame((uint64_t)phys_tables / PAGE_SIZE);
+	pd_entry_t* pd = (pd_entry_t*) get_vaddr_from_frame(((uint64_t)phys_tables / PAGE_SIZE) + 1);
+	pt_entry_t* pt = (pt_entry_t*) get_vaddr_from_frame(((uint64_t)phys_tables / PAGE_SIZE) + 2);
+
+	pdpt[0].present = 1;
+    pdpt[0].read_write = 1;
+    pdpt[0].pd_base_address = (((uint64_t)phys_tables) / PAGE_SIZE) + 1;
+
+    pd[0].present = 1;
+    pd[0].rw = 1;
+    pd[0].pt_base_address = (((uint64_t)phys_tables) / PAGE_SIZE) + 2;
+
 	for (int i = 0; i < 512; i++) {
-		memmap.pt_entry[i].present = 1;
-		memmap.pt_entry[i].rw = 1;
-		memmap.pt_entry[i].frame_base_address =
-			(((uint64_t)initial_frames + PAGE_SIZE * i) >> 12) & 0xFFFFFFFFFF;
+		pt[i].present = 1;
+		pt[i].rw = 1;
+		pt[i].frame_base_address = (((uint64_t)initial_frames / PAGE_SIZE) + i);
 	}
 
 	// initialise PML4T idx 1 and PDPT idx 0 for our page assignments
-	uint64_t pdpt_base_address = ((uint64_t)(get_paddr (&memmap.pdpt_entry[0])));
-	pml4t_entry_t pml4t_entry = {
-		.present = 1,
-		.read_write = 1,
-		.user_supervisor = 0,
-		.page_write_through = 0,
-		.page_cache_disable = 0,
-		.accessed = 0,
-		.ignored1 = 0,
-		.page_size = 0, // must be 0 in PML4
-		.ignored2 = 0,
-		.pdpt_base_address = pdpt_base_address >> 12 & 0xFFFFFFFFFF, // physical address of PDPT
-		.ignored3 = 0,
-		.xd = 1 // execute-disable bit
-	};
-	pml4_base_ptr[1] = pml4t_entry;
+	pml4_base_ptr[1].present = 1;
+    pml4_base_ptr[1].read_write = 1;
+    pml4_base_ptr[1].pdpt_base_address = ((uint64_t)phys_tables) / PAGE_SIZE;
 }
 
 /*!

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -14,6 +14,8 @@ uint64_t hhdm_offset = 0;
 
 bool is_locked = false;
 
+memmap_bitmap bitmap;
+
 extern struct {
 	pdpt_entry_t pdpt_entry[512];
 	pd_entry_t pd_entry[512];
@@ -81,18 +83,18 @@ paddr_t alloc_ppage () {
 	if (bitmap.pages_used >= bitmap.pages_maxlen)
 		return NULL;
 
-	uint64_t total_bytes = (bitmap->pages_maxlen + 7) / 8;
+	uint64_t total_bytes = (bitmap.pages_maxlen + 7) / 8;
 	for (uint64_t i = 0; i < total_bytes; i++) {
-		if (bitmap->map[i] == 0xFF)
+		if (bitmap.map[i] == 0xFF)
 			continue;
 		for (int bit = 0; bit < 8; bit++) {
 			uint64_t idx = i * 8 + bit;
-			if (idx >= bitmap->pages_maxlen)
+			if (idx >= bitmap.pages_maxlen)
 				return NULL;
-			if (!(bitmap->map[i] & (1 << bit))) {
-				bitmap->map[i] |= (1 << bit);
-				bitmap->pages_used++;
-				return (paddr_t)(bitmap->pages_base + PAGE_SIZE * idx);
+			if (!(bitmap.map[i] & (1 << bit))) {
+				bitmap.map[i] |= (1 << bit);
+				bitmap.pages_used++;
+				return (paddr_t)(bitmap.pages_base + PAGE_SIZE * idx);
 			}
 		}
 	}

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -18,6 +18,8 @@ bool is_locked = false;
 
 memmap_bitmap bitmap;
 
+struct limine_memmap_response* memmap_response_ptr;
+
 extern struct {
 	pdpt_entry_t pdpt_entry[512];
 	pd_entry_t pd_entry[512];
@@ -81,27 +83,90 @@ static inline void bitmap_clear_bit (uint64_t page_idx) {
 	}
 }
 
-paddr_t alloc_ppage () {
-	if (bitmap.pages_used >= bitmap.pages_maxlen)
+/*!
+ * Allocate multiple consecutive physical frames
+ * @param count number of consecutive frames to allocate
+ * @return base physical address of allocated frames
+ */
+paddr_t alloc_ppages (uint64_t count) {
+	if (count == 0)
+		return NULL;
+	if (bitmap.pages_used + count > bitmap.pages_maxlen)
 		return NULL;
 
-	uint64_t total_bytes = (bitmap.pages_maxlen + 7) / 8;
-	for (uint64_t i = 0; i < total_bytes; i++) {
-		if (bitmap.map[i] == 0xFF)
+	uint64_t current_streak = 0;
+	uint64_t start_idx = 0;
+
+	for (uint64_t i = 0; i < bitmap.pages_maxlen; i++) {
+		if (i % 8 == 0 && current_streak == 0 && bitmap.map[i / 8] == 0xFF) {
+			i += 7;
 			continue;
-		for (int bit = 0; bit < 8; bit++) {
-			uint64_t idx = i * 8 + bit;
-			if (idx >= bitmap.pages_maxlen)
-				return NULL;
-			if (!(bitmap.map[i] & (1 << bit))) {
-				bitmap.map[i] |= (1 << bit);
-				bitmap.pages_used++;
-				return (paddr_t)(bitmap.pages_base + PAGE_SIZE * idx);
-			}
 		}
+
+		if ((bitmap.map[i / 8] & (1 << (i % 8))) == 0) {
+			if (current_streak == 0)
+				start_idx = i;
+			current_streak++;
+
+			if (current_streak == count) {
+				for (uint64_t j = start_idx; j < start_idx + count; j++)
+					bitmap_set_bit (j);
+				return (paddr_t)(bitmap.pages_base + PAGE_SIZE * start_idx);
+			}
+		} else
+			current_streak = 0;
 	}
+
 	return NULL;
 }
+
+/*!
+ * Allocate a single physical frame
+ * @return base physical address of allocated frame
+ */
+paddr_t alloc_ppage () { return alloc_ppages (1); }
+
+/*!
+ * Free multiple consecutive physical frames
+ * @param paddr base physical address of frames to free
+ * @param count number of frames to free
+ */
+void free_ppages (void* paddr, uint64_t count) {
+	uint64_t start_idx = (uint64_t)paddr / PAGE_SIZE;
+
+	for (uint64_t i = 0; i < count; i++) {
+		uint64_t current_paddr = (uint64_t)paddr + (i * PAGE_SIZE);
+		bool is_valid = false;
+
+		if (memmap_response_ptr != NULL) {
+			for (uint64_t j = 0; j < memmap_response_ptr->entry_count; j++) {
+				struct limine_memmap_entry* entry = memmap_response_ptr->entries[j];
+				if (entry->type == LIMINE_MEMMAP_USABLE && current_paddr >= entry->base &&
+					current_paddr < (entry->base + entry->length)) {
+					is_valid = true;
+					break;
+				}
+			}
+		}
+
+		if (!is_valid) {
+			char buffer[16];
+			ulitos ((uint64_t)paddr, buffer, 16);
+			write_serial_str ("Tried to free reserved memory! Address: 0x");
+			write_serial_str (buffer);
+			write_serial_str ("\nHalting.\n");
+			__asm__ ("hlt");
+		}
+
+		bitmap_clear_bit (start_idx + i);
+	}
+}
+
+/*!
+ * Free a single physical frame
+ * @param paddr base physical address of frame to free
+ */
+void free_ppage (void* paddr) { free_ppages (paddr, 1); }
 
 static void init_physical_bitmap (struct limine_memmap_response* memmap_response) {
 	uint64_t addr_limit = 0;
@@ -183,6 +248,7 @@ void page_fault_handler (registers_t* registers) {
  */
 void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_response) {
 	idt_register_handler (0xE, (irq_handler_t)page_fault_handler);
+	memmap_response_ptr = memmap_response;
 
 	uint64_t pml4_base = read_cr3 () & 0xFFFFFFFFFF000;
 	pml4_base_ptr = (pml4t_entry_t*)(pml4_base + p_hhdm_offset);

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -102,7 +102,7 @@ paddr_t alloc_ppage () {
 	return NULL;
 }
 
-static void init_physical_bitmap (void) {
+static void init_physical_bitmap (struct limine_memmap_response* memmap_response) {
 	uint64_t addr_limit = 0;
 
 	for (uint64_t i = 0; i < memmap_response->entry_count; i++) {
@@ -185,7 +185,7 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 	alloc_frames_limit = highest_length_so_far + best_base_so_far;
 
 	// set up bitmap for physical page allocation
-	init_physical_bitmap ();
+	init_physical_bitmap (memmap_response);
 
 	// set up default memory map
 	memset (&memmap, 0, sizeof (memmap));

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -364,10 +364,25 @@ void* get_paddr (void* vaddr) {
 	if (!pdpt_entry->present)
 		return NULL;
 
+	if (pdpt_entry->page_size) {
+        uint64_t phys_addr = (pdpt_entry->pd_base_address << 12) | 
+                             ((uint64_t)virtual_addr.pd_index << 21) |
+                             ((uint64_t)virtual_addr.pt_index << 12) | 
+                             virtual_addr.offset;
+        return (void*)phys_addr;
+    }
+
 	pd_entry_t* pd_base_ptr = (pd_entry_t*)get_vaddr_from_frame (pdpt_entry->pd_base_address);
 	pd_entry_t* pd_entry = &pd_base_ptr[virtual_addr.pd_index];
 	if (!pd_entry->present)
 		return NULL;
+
+	if (pd_entry->page_size) {
+        uint64_t phys_addr = (pd_entry->pt_base_address << 12) | 
+                             ((uint64_t)virtual_addr.pt_index << 12) |
+                             virtual_addr.offset;
+        return (void*)phys_addr;
+    }
 
 	pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_from_frame (pd_entry->pt_base_address);
 	pt_entry_t* pt_entry = &pt_base_ptr[virtual_addr.pt_index];

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -250,17 +250,17 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 	paddr_t phys_tables = alloc_ppages (3);
 	paddr_t initial_frames = alloc_ppages (512);
 
-	pdpt_entry_t* pdpt = (pdpt_entry_t*) get_vaddr_from_frame((uint64_t)phys_tables / PAGE_SIZE);
-	pd_entry_t* pd = (pd_entry_t*) get_vaddr_from_frame(((uint64_t)phys_tables / PAGE_SIZE) + 1);
-	pt_entry_t* pt = (pt_entry_t*) get_vaddr_from_frame(((uint64_t)phys_tables / PAGE_SIZE) + 2);
+	pdpt_entry_t* pdpt = (pdpt_entry_t*)get_vaddr_from_frame ((uint64_t)phys_tables / PAGE_SIZE);
+	pd_entry_t* pd = (pd_entry_t*)get_vaddr_from_frame (((uint64_t)phys_tables / PAGE_SIZE) + 1);
+	pt_entry_t* pt = (pt_entry_t*)get_vaddr_from_frame (((uint64_t)phys_tables / PAGE_SIZE) + 2);
 
 	pdpt[0].present = 1;
-    pdpt[0].read_write = 1;
-    pdpt[0].pd_base_address = (((uint64_t)phys_tables) / PAGE_SIZE) + 1;
+	pdpt[0].read_write = 1;
+	pdpt[0].pd_base_address = (((uint64_t)phys_tables) / PAGE_SIZE) + 1;
 
-    pd[0].present = 1;
-    pd[0].rw = 1;
-    pd[0].pt_base_address = (((uint64_t)phys_tables) / PAGE_SIZE) + 2;
+	pd[0].present = 1;
+	pd[0].rw = 1;
+	pd[0].pt_base_address = (((uint64_t)phys_tables) / PAGE_SIZE) + 2;
 
 	for (int i = 0; i < 512; i++) {
 		pt[i].present = 1;
@@ -270,8 +270,8 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 
 	// initialise PML4T idx 1 and PDPT idx 0 for our page assignments
 	pml4_base_ptr[1].present = 1;
-    pml4_base_ptr[1].read_write = 1;
-    pml4_base_ptr[1].pdpt_base_address = ((uint64_t)phys_tables) / PAGE_SIZE;
+	pml4_base_ptr[1].read_write = 1;
+	pml4_base_ptr[1].pdpt_base_address = ((uint64_t)phys_tables) / PAGE_SIZE;
 }
 
 /*!
@@ -339,12 +339,11 @@ void* get_paddr (void* vaddr) {
 		return NULL;
 
 	if (pdpt_entry->page_size) {
-        uint64_t phys_addr = (pdpt_entry->pd_base_address << 12) | 
-                             ((uint64_t)virtual_addr.pd_index << 21) |
-                             ((uint64_t)virtual_addr.pt_index << 12) | 
-                             virtual_addr.offset;
-        return (void*)phys_addr;
-    }
+		uint64_t phys_addr = (pdpt_entry->pd_base_address << 12) |
+							 ((uint64_t)virtual_addr.pd_index << 21) |
+							 ((uint64_t)virtual_addr.pt_index << 12) | virtual_addr.offset;
+		return (void*)phys_addr;
+	}
 
 	pd_entry_t* pd_base_ptr = (pd_entry_t*)get_vaddr_from_frame (pdpt_entry->pd_base_address);
 	pd_entry_t* pd_entry = &pd_base_ptr[virtual_addr.pd_index];
@@ -352,11 +351,10 @@ void* get_paddr (void* vaddr) {
 		return NULL;
 
 	if (pd_entry->page_size) {
-        uint64_t phys_addr = (pd_entry->pt_base_address << 12) | 
-                             ((uint64_t)virtual_addr.pt_index << 12) |
-                             virtual_addr.offset;
-        return (void*)phys_addr;
-    }
+		uint64_t phys_addr = (pd_entry->pt_base_address << 12) |
+							 ((uint64_t)virtual_addr.pt_index << 12) | virtual_addr.offset;
+		return (void*)phys_addr;
+	}
 
 	pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_from_frame (pd_entry->pt_base_address);
 	pt_entry_t* pt_entry = &pt_base_ptr[virtual_addr.pt_index];

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -16,12 +16,6 @@ memmap_bitmap bitmap;
 
 struct limine_memmap_response* memmap_response_ptr;
 
-extern struct {
-	pdpt_entry_t pdpt_entry[512];
-	pd_entry_t pd_entry[512];
-	pt_entry_t pt_entry[512];
-} memmap;
-
 /*!
  * Reads the value of the CR3 register, which contains the physical address of the PML4 table.
  * @return The value of the CR3 register.

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -114,7 +114,7 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 	}
 
 	uint64_t total_pages = addr_limit / PAGE_SIZE;
-	uint64_t bitmap_size = (total_bytes + 7) / 8;
+	uint64_t bitmap_size = (total_pages + 7) / 8;
 
 	void* bitmap_phys_addr = NULL;
 	for (uint64_t i=0; i<memmap_response->entry_count; i++) {
@@ -145,7 +145,7 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 		struct limine_memmap_entry* entry = memmap_response->entries[i];
 		if (entry->type == LIMINE_MEMMAP_USABLE) {
 			for (uint64_t p = entry->base / PAGE_SIZE ; p < (entry->base + entry->length) / PAGE_SIZE ; p++) {
-				if (p < bitmap_fst_page || p >= bitmap_end_page) bitmap_clear_bit(p);
+				if (p < bitmap_fst_page || p >= bitmap_lst_page) bitmap_clear_bit(p);
 			}
 		}
 	}

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -64,20 +64,20 @@ inline void* get_vaddr_hhdm (uint64_t phys_address) {
  * Set a bit in the memory bitmap
  * @param page_idx page index
  */
-static inline void bitmap_set_bit(uint64_t page_idx) {
-    bitmap.map[page_idx / 8] |= (1 << (page_idx % 8));
-    bitmap.pages_used++;
+static inline void bitmap_set_bit (uint64_t page_idx) {
+	bitmap.map[page_idx / 8] |= (1 << (page_idx % 8));
+	bitmap.pages_used++;
 }
 
 /*!
  * Clear a bit in the memory bitmap
  * @param page_idx page index
  */
-static inline void bitmap_clear_bit(uint64_t page_idx) {
-    if (bitmap.map[page_idx / 8] & (1 << (page_idx % 8))) {
-        bitmap.map[page_idx / 8] &= ~(1 << (page_idx % 8));
-        bitmap.pages_used--;
-    }
+static inline void bitmap_clear_bit (uint64_t page_idx) {
+	if (bitmap.map[page_idx / 8] & (1 << (page_idx % 8))) {
+		bitmap.map[page_idx / 8] &= ~(1 << (page_idx % 8));
+		bitmap.pages_used--;
+	}
 }
 
 paddr_t alloc_ppage () {
@@ -109,7 +109,8 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 		struct limine_memmap_entry* entry = memmap_response->entries[i];
 		if (entry->type == LIMINE_MEMMAP_USABLE) {
 			uint64_t top = entry->base + entry->length;
-			if (top > addr_limit) addr_limit = top;
+			if (top > addr_limit)
+				addr_limit = top;
 		}
 	}
 
@@ -117,35 +118,38 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 	uint64_t bitmap_size = (total_pages + 7) / 8;
 
 	void* bitmap_phys_addr = NULL;
-	for (uint64_t i=0; i<memmap_response->entry_count; i++) {
+	for (uint64_t i = 0; i < memmap_response->entry_count; i++) {
 		struct limine_memmap_entry* entry = memmap_response->entries[i];
 		if (entry->type == LIMINE_MEMMAP_USABLE && entry->length >= bitmap_size) {
-			bitmap_phys_addr = (void*) entry->base;
+			bitmap_phys_addr = (void*)entry->base;
 			break;
 		}
 	}
 
 	if (bitmap_phys_addr == NULL) {
-		write_serial_str ("Not enough contiguous memory for bitmap setup!! Please download some RAM.\n");
-		printf("Not enough contiguous memory for bitmap setup!! Please download some RAM.\n");
+		write_serial_str (
+			"Not enough contiguous memory for bitmap setup!! Please download some RAM.\n");
+		printf ("Not enough contiguous memory for bitmap setup!! Please download some RAM.\n");
 		__asm__ ("hlt");
 	}
 
-	bitmap.map = (uint8_t*) get_vaddr_hhdm ((uint64_t)bitmap_phys_addr);
+	bitmap.map = (uint8_t*)get_vaddr_hhdm ((uint64_t)bitmap_phys_addr);
 	bitmap.pages_base = 0;
 	bitmap.pages_maxlen = total_pages;
 	bitmap.pages_used = total_pages;
 
-	memset(bitmap.map, 0xFF, bitmap_size);
+	memset (bitmap.map, 0xFF, bitmap_size);
 
-	uint64_t bitmap_fst_page = (uint64_t) bitmap_phys_addr / PAGE_SIZE;
-	uint64_t bitmap_lst_page = bitmap_fst_page + ((bitmap_size + PAGE_SIZE -1)/PAGE_SIZE);
+	uint64_t bitmap_fst_page = (uint64_t)bitmap_phys_addr / PAGE_SIZE;
+	uint64_t bitmap_lst_page = bitmap_fst_page + ((bitmap_size + PAGE_SIZE - 1) / PAGE_SIZE);
 
-	for (uint64_t i = 0; i<memmap_response->entry_count; i++) {
+	for (uint64_t i = 0; i < memmap_response->entry_count; i++) {
 		struct limine_memmap_entry* entry = memmap_response->entries[i];
 		if (entry->type == LIMINE_MEMMAP_USABLE) {
-			for (uint64_t p = entry->base / PAGE_SIZE ; p < (entry->base + entry->length) / PAGE_SIZE ; p++) {
-				if (p < bitmap_fst_page || p >= bitmap_lst_page) bitmap_clear_bit(p);
+			for (uint64_t p = entry->base / PAGE_SIZE;
+				 p < (entry->base + entry->length) / PAGE_SIZE; p++) {
+				if (p < bitmap_fst_page || p >= bitmap_lst_page)
+					bitmap_clear_bit (p);
 			}
 		}
 	}

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -7,10 +7,6 @@
 
 #define PAGE_SIZE 4096
 
-uint64_t alloc_frames_base = 0;
-uint64_t alloc_frames_count = 0;
-uint64_t alloc_frames_limit = 0;
-
 pml4t_entry_t* pml4_base_ptr = NULL;
 uint64_t hhdm_offset = 0;
 
@@ -254,29 +250,6 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 	pml4_base_ptr = (pml4t_entry_t*)(pml4_base + p_hhdm_offset);
 	hhdm_offset = p_hhdm_offset;
 
-	uint64_t highest_length_so_far = 0;
-	uint64_t best_base_so_far = 0xffffffffffffffff;
-
-	// set permissible limit
-	if (memmap_response != NULL) {
-		for (uint64_t i = 0; i < memmap_response->entry_count; i++) {
-			if (memmap_response->entries[i]->type == 0) {
-				if (memmap_response->entries[i]->length > highest_length_so_far) {
-					highest_length_so_far = memmap_response->entries[i]->length;
-					best_base_so_far = memmap_response->entries[i]->base;
-				}
-			}
-		}
-	}
-
-	if (highest_length_so_far < PAGE_SIZE * 16) {
-		printf ("Too little memory!! (0x%lx bytes)\n", highest_length_so_far);
-		return;
-	}
-
-	alloc_frames_base = best_base_so_far;
-	alloc_frames_limit = highest_length_so_far + best_base_so_far;
-
 	// set up bitmap for physical page allocation
 	init_physical_bitmap (memmap_response);
 
@@ -299,11 +272,13 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 			((uint64_t)(get_paddr (&memmap.pt_entry[i * 512])) >> 12) & 0xFFFFFFFFFF;
 	}
 
+	paddr_t initial_frames = alloc_ppages (512);
+
 	for (int i = 0; i < 512; i++) {
 		memmap.pt_entry[i].present = 1;
 		memmap.pt_entry[i].rw = 1;
 		memmap.pt_entry[i].frame_base_address =
-			((uint64_t)(alloc_frames_base + PAGE_SIZE * i) >> 12) & 0xFFFFFFFFFF;
+			(((uint64_t)initial_frames + PAGE_SIZE * i) >> 12) & 0xFFFFFFFFFF;
 	}
 
 	// initialise PML4T idx 1 and PDPT idx 0 for our page assignments
@@ -323,17 +298,6 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 		.xd = 1 // execute-disable bit
 	};
 	pml4_base_ptr[1] = pml4t_entry;
-}
-
-uint64_t allocate_physical_pageframes (size_t count) {
-	if (alloc_frames_base + (PAGE_SIZE * (alloc_frames_count + count)) > alloc_frames_limit)
-		return 0;
-	if (is_locked)
-		return 0;
-
-	uint64_t allocated_memory = alloc_frames_base + (PAGE_SIZE * alloc_frames_count);
-	alloc_frames_count += count;
-	return allocated_memory;
 }
 
 /*!

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -57,8 +57,28 @@ inline void* get_vaddr_hhdm (uint64_t phys_address) {
 	return (void*)((phys_address << 12) + hhdm_offset);
 }
 
-paddr_t alloc_ppage (memmap_bitmap* bitmap) {
-	if (bitmap->pages_used >= bitmap->pages_maxlen)
+/*!
+ * Set a bit in the memory bitmap
+ * @param page_idx page index
+ */
+static inline void bitmap_set_bit(uint64_t page_idx) {
+    bitmap.map[page_idx / 8] |= (1 << (page_idx % 8));
+    bitmap.pages_used++;
+}
+
+/*!
+ * Clear a bit in the memory bitmap
+ * @param page_idx page index
+ */
+static inline void bitmap_clear_bit(uint64_t page_idx) {
+    if (bitmap.map[page_idx / 8] & (1 << (page_idx % 8))) {
+        bitmap.map[page_idx / 8] &= ~(1 << (page_idx % 8));
+        bitmap.pages_used--;
+    }
+}
+
+paddr_t alloc_ppage () {
+	if (bitmap.pages_used >= bitmap.pages_maxlen)
 		return NULL;
 
 	uint64_t total_bytes = (bitmap->pages_maxlen + 7) / 8;

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -1,3 +1,4 @@
+#include <kernel/idt.h>
 #include <kernel/limine.h>
 #include <kernel/memmgt.h>
 #include <kernel/serial.h>
@@ -156,11 +157,33 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 }
 
 /*!
+ * Simple handler for page fault, prints faulting address from CR2
+ * @param registers idt-passed registers object
+ */
+void page_fault_handler (registers_t* registers) {
+	uint64_t cr2;
+	__asm__ volatile ("mov %%cr2, %0" : "=r"(cr2));
+
+	char buffer[16];
+	ulitos (cr2, buffer, 16);
+
+	write_serial_str ("\nEncountered a page fault!\n");
+	write_serial_str ("Faulting address: 0x");
+	write_serial_str (buffer);
+	write_serial ('\n');
+
+	for (;;)
+		__asm__ volatile ("hlt");
+}
+
+/*!
  * Initializes the memory management subsystem.
  * Sets the base pointer for the PML4 table and stores the HHDM offset.
  * @param p_hhdm_offset The higher half direct mapping offset.
  */
 void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_response) {
+	idt_register_handler (0xE, (irq_handler_t)page_fault_handler);
+
 	uint64_t pml4_base = read_cr3 () & 0xFFFFFFFFFF000;
 	pml4_base_ptr = (pml4t_entry_t*)(pml4_base + p_hhdm_offset);
 	hhdm_offset = p_hhdm_offset;

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -53,12 +53,12 @@ vaddr_t get_vaddr_t_from_ptr (void* ptr) {
 }
 
 /*!
- * Convert a physical frame address to vaddr pointer with HHDM mapping
- * @param phys_address the physical address
+ * Convert a physical frame to vaddr pointer with HHDM mapping
+ * @param phys_frame the physical frame
  * @return pointer to virtual memory using HHDM mapping
  */
-inline void* get_vaddr_hhdm (uint64_t phys_address) {
-	return (void*)((phys_address << 12) + hhdm_offset);
+inline void* get_vaddr_from_frame (uint64_t phys_frame) {
+	return (void*)((phys_frame << 12) + hhdm_offset);
 }
 
 /*!
@@ -134,7 +134,7 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 		__asm__ ("hlt");
 	}
 
-	bitmap.map = (uint8_t*)get_vaddr_hhdm ((uint64_t)bitmap_phys_addr);
+	bitmap.map = (uint8_t*)((uint64_t)bitmap_phys_addr + hhdm_offset);
 	bitmap.pages_base = 0;
 	bitmap.pages_maxlen = total_pages;
 	bitmap.pages_used = total_pages;
@@ -278,18 +278,19 @@ void walk_pagetable () {
 	if (!pml4t_entry->present)
 		return;
 
-	pdpt_entry_t* pdpt_base_ptr = (pdpt_entry_t*)get_vaddr_hhdm (pml4t_entry->pdpt_base_address);
+	pdpt_entry_t* pdpt_base_ptr =
+		(pdpt_entry_t*)get_vaddr_from_frame (pml4t_entry->pdpt_base_address);
 	pdpt_entry_t* pdpt_entry = &pdpt_base_ptr[0];
 	if (!pdpt_entry->present)
 		return;
 
-	pd_entry_t* pd_base_ptr = (pd_entry_t*)get_vaddr_hhdm (pdpt_entry->pd_base_address);
+	pd_entry_t* pd_base_ptr = (pd_entry_t*)get_vaddr_from_frame (pdpt_entry->pd_base_address);
 	for (int k = 0; k < 512; k++) {
 		pd_entry_t* pd_entry = &pd_base_ptr[k];
 		if (!pd_entry->present)
 			continue;
 		printf ("PD %d: PT Base Address:   0x%lx\n", k, pd_entry->pt_base_address << 12);
-		pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_hhdm (pd_entry->pt_base_address);
+		pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_from_frame (pd_entry->pt_base_address);
 
 		bool is_present_pt[512] = {false};
 		for (int k = 0; k < 512; k++)
@@ -327,17 +328,18 @@ void* get_paddr (void* vaddr) {
 	if (!pml4t_entry->present)
 		return NULL;
 
-	pdpt_entry_t* pdpt_base_ptr = (pdpt_entry_t*)get_vaddr_hhdm (pml4t_entry->pdpt_base_address);
+	pdpt_entry_t* pdpt_base_ptr =
+		(pdpt_entry_t*)get_vaddr_from_frame (pml4t_entry->pdpt_base_address);
 	pdpt_entry_t* pdpt_entry = &pdpt_base_ptr[virtual_addr.pdpt_index];
 	if (!pdpt_entry->present)
 		return NULL;
 
-	pd_entry_t* pd_base_ptr = (pd_entry_t*)get_vaddr_hhdm (pdpt_entry->pd_base_address);
+	pd_entry_t* pd_base_ptr = (pd_entry_t*)get_vaddr_from_frame (pdpt_entry->pd_base_address);
 	pd_entry_t* pd_entry = &pd_base_ptr[virtual_addr.pd_index];
 	if (!pd_entry->present)
 		return NULL;
 
-	pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_hhdm (pd_entry->pt_base_address);
+	pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_from_frame (pd_entry->pt_base_address);
 	pt_entry_t* pt_entry = &pt_base_ptr[virtual_addr.pt_index];
 	if (!pt_entry->present)
 		return NULL;
@@ -390,13 +392,14 @@ void* liballoc_alloc (size_t count) {
 	pml4t_entry_t* pml4t_entry = &pml4_base_ptr[1];
 	if (!pml4t_entry->present)
 		return NULL;
-	pdpt_entry_t* pdpt_entry = &((pdpt_entry_t*)get_vaddr_hhdm (pml4t_entry->pdpt_base_address))[0];
+	pdpt_entry_t* pdpt_entry =
+		&((pdpt_entry_t*)get_vaddr_from_frame (pml4t_entry->pdpt_base_address))[0];
 	if (!pdpt_entry->present)
 		return NULL;
-	pd_entry_t* pd_entry = &((pd_entry_t*)get_vaddr_hhdm (pdpt_entry->pd_base_address))[0];
+	pd_entry_t* pd_entry = &((pd_entry_t*)get_vaddr_from_frame (pdpt_entry->pd_base_address))[0];
 	if (!pd_entry->present)
 		return NULL;
-	pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_hhdm (pd_entry->pt_base_address);
+	pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_from_frame (pd_entry->pt_base_address);
 
 	return try_assign_pt (pt_base_ptr, count);
 }
@@ -413,14 +416,14 @@ int liballoc_free (void* ptr, size_t count) {
 	if (!pml4t_entry->present || vaddr.pml4_index != 1)
 		return -2;
 	pdpt_entry_t* pdpt_entry =
-		&((pdpt_entry_t*)get_vaddr_hhdm (pml4t_entry->pdpt_base_address))[vaddr.pdpt_index];
+		&((pdpt_entry_t*)get_vaddr_from_frame (pml4t_entry->pdpt_base_address))[vaddr.pdpt_index];
 	if (!pdpt_entry->present || vaddr.pdpt_index != 0)
 		return -3;
 	pd_entry_t* pd_entry =
-		&((pd_entry_t*)get_vaddr_hhdm (pdpt_entry->pd_base_address))[vaddr.pd_index];
+		&((pd_entry_t*)get_vaddr_from_frame (pdpt_entry->pd_base_address))[vaddr.pd_index];
 	if (!pd_entry->present || vaddr.pd_index != 0)
 		return -4;
-	pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_hhdm (pd_entry->pt_base_address);
+	pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_from_frame (pd_entry->pt_base_address);
 
 	for (size_t i = 0; i < count; i++) {
 		if (i + vaddr.pt_index >= 512)

--- a/src/kernel/memmgt.c
+++ b/src/kernel/memmgt.c
@@ -1,5 +1,6 @@
 #include <kernel/limine.h>
 #include <kernel/memmgt.h>
+#include <kernel/serial.h>
 #include <memory.h>
 #include <stdio.h>
 
@@ -101,6 +102,55 @@ paddr_t alloc_ppage () {
 	return NULL;
 }
 
+static void init_physical_bitmap (void) {
+	uint64_t addr_limit = 0;
+
+	for (uint64_t i = 0; i < memmap_response->entry_count; i++) {
+		struct limine_memmap_entry* entry = memmap_response->entries[i];
+		if (entry->type == LIMINE_MEMMAP_USABLE) {
+			uint64_t top = entry->base + entry->length;
+			if (top > addr_limit) addr_limit = top;
+		}
+	}
+
+	uint64_t total_pages = addr_limit / PAGE_SIZE;
+	uint64_t bitmap_size = (total_bytes + 7) / 8;
+
+	void* bitmap_phys_addr = NULL;
+	for (uint64_t i=0; i<memmap_response->entry_count; i++) {
+		struct limine_memmap_entry* entry = memmap_response->entries[i];
+		if (entry->type == LIMINE_MEMMAP_USABLE && entry->length >= bitmap_size) {
+			bitmap_phys_addr = (void*) entry->base;
+			break;
+		}
+	}
+
+	if (bitmap_phys_addr == NULL) {
+		write_serial_str ("Not enough contiguous memory for bitmap setup!! Please download some RAM.\n");
+		printf("Not enough contiguous memory for bitmap setup!! Please download some RAM.\n");
+		__asm__ ("hlt");
+	}
+
+	bitmap.map = (uint8_t*) get_vaddr_hhdm ((uint64_t)bitmap_phys_addr);
+	bitmap.pages_base = 0;
+	bitmap.pages_maxlen = total_pages;
+	bitmap.pages_used = total_pages;
+
+	memset(bitmap.map, 0xFF, bitmap_size);
+
+	uint64_t bitmap_fst_page = (uint64_t) bitmap_phys_addr / PAGE_SIZE;
+	uint64_t bitmap_lst_page = bitmap_fst_page + ((bitmap_size + PAGE_SIZE -1)/PAGE_SIZE);
+
+	for (uint64_t i = 0; i<memmap_response->entry_count; i++) {
+		struct limine_memmap_entry* entry = memmap_response->entries[i];
+		if (entry->type == LIMINE_MEMMAP_USABLE) {
+			for (uint64_t p = entry->base / PAGE_SIZE ; p < (entry->base + entry->length) / PAGE_SIZE ; p++) {
+				if (p < bitmap_fst_page || p >= bitmap_end_page) bitmap_clear_bit(p);
+			}
+		}
+	}
+}
+
 /*!
  * Initializes the memory management subsystem.
  * Sets the base pointer for the PML4 table and stores the HHDM offset.
@@ -135,10 +185,7 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 	alloc_frames_limit = highest_length_so_far + best_base_so_far;
 
 	// set up bitmap for physical page allocation
-	memmap_bitmap bitmap;
-	bitmap.pages_base = alloc_frames_base;
-	bitmap.pages_maxlen = 13 * PAGE_SIZE * 8;
-	bitmap.pages_used = 0;
+	init_physical_bitmap ();
 
 	// set up default memory map
 	memset (&memmap, 0, sizeof (memmap));

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -48,11 +48,6 @@ SECTIONS
 	.data : {
 		*(.data .data.*)
 	} :data
-
-	.memory_map : ALIGN(0x1000)
-    {
-        KEEP(*(.memory_map))
-    } :data
  
 	/* NOTE: .bss needs to be the last thing mapped to :data, otherwise lots of */
 	/* unnecessary zeros will be written to the binary. */


### PR DESCRIPTION
This pull request brings several key improvements to the kernel's memory management subsystem:

- **New Bitmap Physical Allocator**: Implemented a bitmap-based physical memory allocator (`alloc_ppage`/`alloc_ppages`) to efficiently track and manage usable frames based on the bootloader's memory map.
- **Deprecation of Old Memory Map Structure**: Removed the reliance on the older, static memory map representations in favor of directly integrating with the Limine memory map structure (`limine_memmap_response`). 
- **Dynamic Allocation for Page Tables**: Switched from statically defined initial page table structures to dynamically allocating physical frames for the initial PDPT, PD, and PT structures in `init_memmgt`.