### PR TITLE
Cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,4 @@ SpaceBeforeParens: Always
 ColumnLimit: 100
 BreakBeforeBraces: Attach
 RemoveBracesLLVM: true
+AlignConsecutiveMacros: true

--- a/.clang-format
+++ b/.clang-format
@@ -7,3 +7,4 @@ ColumnLimit: 100
 BreakBeforeBraces: Attach
 RemoveBracesLLVM: true
 AlignConsecutiveMacros: true
+AllowShortIfStatementsOnASingleLine: WithoutElse

--- a/.clang-format
+++ b/.clang-format
@@ -9,3 +9,4 @@ RemoveBracesLLVM: true
 AlignConsecutiveMacros: true
 AllowShortIfStatementsOnASingleLine: WithoutElse
 ReflowComments: true
+SortIncludes: true

--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ PointerAlignment: Left
 SpaceBeforeParens: Always
 ColumnLimit: 100
 BreakBeforeBraces: Attach
+RemoveBracesLLVM: true

--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,4 @@ BreakBeforeBraces: Attach
 RemoveBracesLLVM: true
 AlignConsecutiveMacros: true
 AllowShortIfStatementsOnASingleLine: WithoutElse
+ReflowComments: true

--- a/.clang-format
+++ b/.clang-format
@@ -10,3 +10,4 @@ AlignConsecutiveMacros: true
 AllowShortIfStatementsOnASingleLine: WithoutElse
 ReflowComments: true
 SortIncludes: true
+AlignConsecutiveDeclarations: true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Documentation is sparse, but you can use doxygen to build it from the in-code co
 
 - It boots up on most modern-day 64-bit systems that support x86_64 (so no ARM)
 - It can print stuff on your screen
-- It can do some basic memory management with paging
+- It can manage upto 512GB of virtual memory
+- It can read an initramfs and enter user mode
 - More to come
 
 ## Setup

--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -60,6 +60,9 @@ override CFLAGS += \
 	-mno-sse2 \
 	-mno-red-zone \
 	-mcmodel=kernel
+
+# TODO: add these flags: -Wconversion -Wsign-conversion -Wcast-align \
+# -Wpointer-arith -Wshadow
  
 # Internal C preprocessor flags that should not be changed by the user.
 override CPPFLAGS := \

--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -42,6 +42,8 @@ override CFLAGS += \
 	-Wall \
 	-Wextra \
 	-Wstrict-prototypes \
+	-Wmissing-prototypes \
+	-Wmissing-declarations \
 	-std=gnu11 \
 	-ffreestanding \
 	-fno-stack-protector \

--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -41,6 +41,7 @@ $(eval $(call DEFAULT_VAR,LDFLAGS,$(DEFAULT_LDFLAGS)))
 override CFLAGS += \
 	-Wall \
 	-Wextra \
+	-Wstrict-prototypes \
 	-std=gnu11 \
 	-ffreestanding \
 	-fno-stack-protector \

--- a/kernel/include/kernel/console.h
+++ b/kernel/include/kernel/console.h
@@ -8,13 +8,13 @@
 #define TAB_WIDTH 8
 
 void set_update_on_putch (bool);
-bool get_update_on_putch ();
+bool get_update_on_putch (void);
 void set_idx (size_t);
-size_t get_idx ();
+size_t get_idx (void);
 
 void init_console (size_t, size_t, size_t, size_t, size_t, size_t, size_t);
 void set_color (uint32_t);
-void update ();
+void update (void);
 
 void putchar (unsigned char);
 void putstr (const char*, size_t);

--- a/kernel/include/kernel/console.h
+++ b/kernel/include/kernel/console.h
@@ -7,9 +7,9 @@
 
 #define TAB_WIDTH 8
 
-void set_update_on_putch (bool);
-bool get_update_on_putch (void);
-void set_idx (size_t);
+void   set_update_on_putch (bool);
+bool   get_update_on_putch (void);
+void   set_idx (size_t);
 size_t get_idx (void);
 
 void init_console (size_t, size_t, size_t, size_t, size_t, size_t, size_t);

--- a/kernel/include/kernel/console.h
+++ b/kernel/include/kernel/console.h
@@ -12,7 +12,7 @@ bool get_update_on_putch ();
 void set_idx (size_t);
 size_t get_idx ();
 
-void __init_console__ (size_t, size_t, size_t, size_t, size_t, size_t, size_t);
+void init_console (size_t, size_t, size_t, size_t, size_t, size_t, size_t);
 void set_color (uint32_t);
 void update ();
 

--- a/kernel/include/kernel/fs/cpio.h
+++ b/kernel/include/kernel/fs/cpio.h
@@ -23,7 +23,7 @@ typedef struct {
 } cpio_newc_header_t;
 
 typedef struct {
-	char* c_name;
+	char*  c_name;
 	inode* c_inode;
 } child_t;
 

--- a/kernel/include/kernel/fs/cpio.h
+++ b/kernel/include/kernel/fs/cpio.h
@@ -36,6 +36,6 @@ int mkdir (char* dirname, inode** result, inode* root);
 int create (char* filename, inode** result, inode* root);
 int lookup (char* filename, inode** result, inode* root);
 
-void load_initramfs (void* pos, size_t size);
+void load_initramfs (void* pos);
 
 #endif

--- a/kernel/include/kernel/fs/vfs.h
+++ b/kernel/include/kernel/fs/vfs.h
@@ -7,7 +7,7 @@
 typedef enum { UNDEF, EFILE, DIRECTORY, LINK } file_type_t;
 
 typedef struct inode inode;
-typedef struct file file;
+typedef struct file	 file;
 
 typedef struct {
 	int (*lookup) (char*, inode**, inode*);
@@ -23,15 +23,15 @@ typedef struct {
 } file_operations;
 
 struct inode {
-	uint64_t i_no, i_sz;
-	void* i_pvt;
+	uint64_t		  i_no, i_sz;
+	void*			  i_pvt;
 	inode_operations* i_iops;
-	file_type_t i_type;
+	file_type_t		  i_type;
 };
 
 struct file {
-	inode* f_inode;
-	uint64_t f_pos, f_cnt;
+	inode*			 f_inode;
+	uint64_t		 f_pos, f_cnt;
 	file_operations* f_fops;
 };
 

--- a/kernel/include/kernel/fs/vfs.h
+++ b/kernel/include/kernel/fs/vfs.h
@@ -27,7 +27,6 @@ struct inode {
 	void* i_pvt;
 	inode_operations* i_iops;
 	file_type_t i_type;
-	char* i_filename;
 };
 
 struct file {

--- a/kernel/include/kernel/gdt.h
+++ b/kernel/include/kernel/gdt.h
@@ -9,19 +9,19 @@ typedef struct __attribute__ ((packed)) {
 typedef struct __attribute__ ((packed)) {
 	uint16_t limit;
 	uint16_t base_low16;
-	uint8_t base_mid8;
-	uint8_t access;
-	uint8_t granularity;
-	uint8_t base_high8;
+	uint8_t	 base_mid8;
+	uint8_t	 access;
+	uint8_t	 granularity;
+	uint8_t	 base_high8;
 } gdt_entry_t;
 
 typedef struct __attribute__ ((packed)) {
 	uint16_t length;
 	uint16_t base_low16;
-	uint8_t base_mid8;
-	uint8_t flags0;
-	uint8_t flags1;
-	uint8_t base_high8;
+	uint8_t	 base_mid8;
+	uint8_t	 flags0;
+	uint8_t	 flags1;
+	uint8_t	 base_high8;
 	uint32_t base_upper32;
 	uint32_t reserved;
 } tss_entry_t;
@@ -53,5 +53,6 @@ typedef struct __attribute__ ((packed)) {
 void init_gdt (void);
 void init_tss (void);
 void tss_set_stack (uintptr_t stack);
+
 extern void gdt_flush (gdt_pointer_t*);
 extern void tss_flush (void);

--- a/kernel/include/kernel/gdt.h
+++ b/kernel/include/kernel/gdt.h
@@ -50,8 +50,8 @@ typedef struct __attribute__ ((packed)) {
 	tss_entry_t tss;
 } gdt_t;
 
-void gdt_init (void);
-void tss_init (void);
+void init_gdt (void);
+void init_tss (void);
 void tss_set_stack (uintptr_t stack);
 extern void gdt_flush (gdt_pointer_t*);
 extern void tss_flush (void);

--- a/kernel/include/kernel/graphics.h
+++ b/kernel/include/kernel/graphics.h
@@ -11,7 +11,7 @@ struct posn {
 
 extern void init_graphics (struct limine_framebuffer*);
 struct posn itopos (int);
-size_t postoi (int, int);
+size_t		postoi (int, int);
 
 void renderGlyph (unsigned char*, int, int, size_t, size_t, int, uint32_t);
 

--- a/kernel/include/kernel/graphics.h
+++ b/kernel/include/kernel/graphics.h
@@ -9,7 +9,7 @@ struct posn {
 	size_t y;
 };
 
-extern void __init_graphics__ (struct limine_framebuffer*);
+extern void init_graphics (struct limine_framebuffer*);
 struct posn itopos (int);
 size_t postoi (int, int);
 

--- a/kernel/include/kernel/handlers.h
+++ b/kernel/include/kernel/handlers.h
@@ -6,6 +6,6 @@
 
 void handle_gpf (registers_t* registers);
 
-void __init_handlers__ ();
+void init_handlers ();
 
 #endif

--- a/kernel/include/kernel/handlers.h
+++ b/kernel/include/kernel/handlers.h
@@ -6,6 +6,6 @@
 
 void handle_gpf (registers_t* registers);
 
-void init_handlers ();
+void init_handlers (void);
 
 #endif

--- a/kernel/include/kernel/hardfonts/classic.h
+++ b/kernel/include/kernel/hardfonts/classic.h
@@ -1,6 +1,6 @@
 #ifndef CLASSIC_H
 #define CLASSIC_H
 
-unsigned char* glyph (char);
+unsigned char* glyph (char index);
 
 #endif

--- a/kernel/include/kernel/hw/pic.h
+++ b/kernel/include/kernel/hw/pic.h
@@ -18,6 +18,6 @@ void pic_clr_mask (uint8_t irq_line);
 
 void pic_send_eoi (uint8_t irq);
 
-void __init_pic__ (void);
+void init_pic (void);
 
 #endif

--- a/kernel/include/kernel/hw/pic.h
+++ b/kernel/include/kernel/hw/pic.h
@@ -5,13 +5,13 @@
 #include <kernel/io.h>
 #include <stdint.h>
 
-#define PIC1 0x20
-#define PIC2 0xA0
+#define PIC1		 0x20
+#define PIC2		 0xA0
 #define PIC1_COMMAND PIC1
-#define PIC1_DATA (PIC1 + 1)
+#define PIC1_DATA	 (PIC1 + 1)
 #define PIC2_COMMAND PIC2
-#define PIC2_DATA (PIC2 + 1)
-#define PIC_EOI 0x20
+#define PIC2_DATA	 (PIC2 + 1)
+#define PIC_EOI		 0x20
 
 void pic_set_mask (uint8_t irq_line);
 void pic_clr_mask (uint8_t irq_line);

--- a/kernel/include/kernel/idt.h
+++ b/kernel/include/kernel/idt.h
@@ -14,12 +14,12 @@ typedef struct __attribute__ ((packed)) {
 typedef struct __attribute__ ((packed)) {
 	uint16_t offset_1;
 	uint16_t selector;
-	uint8_t ist : 3;
-	uint8_t zero_1 : 5;
-	uint8_t gate_type : 4;
-	uint8_t zero_2 : 1;
-	uint8_t dpl : 2;
-	uint8_t present : 1;
+	uint8_t	 ist : 3;
+	uint8_t	 zero_1 : 5;
+	uint8_t	 gate_type : 4;
+	uint8_t	 zero_2 : 1;
+	uint8_t	 dpl : 2;
+	uint8_t	 present : 1;
 	uint16_t offset_2;
 	uint32_t offset_3;
 	uint32_t zero_3;

--- a/kernel/include/kernel/idt.h
+++ b/kernel/include/kernel/idt.h
@@ -34,7 +34,7 @@ typedef struct __attribute__ ((packed)) {
 
 typedef void (*irq_handler_t) (registers_t*);
 
-void __init_idt__ (void);
+void init_idt (void);
 void idt_register_handler (int vector, irq_handler_t handler);
 void idt_set_flags (int vector, uint8_t gate_type, uint8_t dpl, uint8_t ist);
 

--- a/kernel/include/kernel/io.h
+++ b/kernel/include/kernel/io.h
@@ -4,8 +4,8 @@
 
 #include <stdint.h>
 
-void outb (uint16_t port, uint8_t val);
+void	outb (uint16_t port, uint8_t val);
 uint8_t inb (uint16_t port);
-void io_wait (void);
+void	io_wait (void);
 
 #endif

--- a/kernel/include/kernel/memmgt.h
+++ b/kernel/include/kernel/memmgt.h
@@ -86,24 +86,24 @@ typedef struct {
 typedef uint64_t* paddr_t;
 
 vaddr_t get_vaddr_t_from_ptr (void* ptr);
-void* get_vaddr_hhdm (uint64_t phys_address);
-void* vaddr_t_to_ptr (vaddr_t* virtual_addr);
+void*	get_vaddr_hhdm (uint64_t phys_address);
+void*	vaddr_t_to_ptr (vaddr_t* virtual_addr);
 
 void* alloc_vpages (size_t req_count, bool user);
 void* alloc_vpage (bool user);
-void free_vpages (void* ptr, size_t count);
-void free_vpage (void* ptr);
+void  free_vpages (void* ptr, size_t count);
+void  free_vpage (void* ptr);
 
-void init_memmgt (uint64_t, struct limine_memmap_response*);
-void walk_pagetable (void);
+void  init_memmgt (uint64_t, struct limine_memmap_response*);
+void  walk_pagetable (void);
 void* get_paddr (void* vaddr);
 
 // LIBALLOC FUNCTION IMPLEMENTATIONS
 
 void* try_assign_pt (pt_entry_t*, size_t);
-int liballoc_lock (void);
-int liballoc_unlock (void);
+int	  liballoc_lock (void);
+int	  liballoc_unlock (void);
 void* liballoc_alloc (size_t);
-int liballoc_free (void*, size_t);
+int	  liballoc_free (void*, size_t);
 
 #endif

--- a/kernel/include/kernel/memmgt.h
+++ b/kernel/include/kernel/memmgt.h
@@ -101,8 +101,8 @@ void* get_paddr (void* vaddr);
 // LIBALLOC FUNCTION IMPLEMENTATIONS
 
 void* try_assign_pt (pt_entry_t*, size_t);
-int liballoc_lock ();
-int liballoc_unlock ();
+int liballoc_lock (void);
+int liballoc_unlock (void);
 void* liballoc_alloc (size_t);
 int liballoc_free (void*, size_t);
 

--- a/kernel/include/kernel/memmgt.h
+++ b/kernel/include/kernel/memmgt.h
@@ -94,7 +94,7 @@ void* alloc_vpage (bool user);
 void free_vpages (void* ptr, size_t count);
 void free_vpage (void* ptr);
 
-void __init_memmgt__ (uint64_t, struct limine_memmap_response*);
+void init_memmgt (uint64_t, struct limine_memmap_response*);
 void walk_pagetable (void);
 void* get_paddr (void* vaddr);
 

--- a/kernel/include/kernel/serial.h
+++ b/kernel/include/kernel/serial.h
@@ -11,7 +11,7 @@
 int init_serial (void);
 
 uint8_t read_serial (void);
-void write_serial (uint8_t val);
-void write_serial_str (const char* str);
+void	write_serial (uint8_t val);
+void	write_serial_str (const char* str);
 
 #endif

--- a/kernel/include/kernel/serial.h
+++ b/kernel/include/kernel/serial.h
@@ -8,7 +8,7 @@
 
 #include <kernel/io.h>
 
-int __init_serial__ (void);
+int init_serial (void);
 
 uint8_t read_serial (void);
 void write_serial (uint8_t val);

--- a/kernel/include/kernel/syscall.h
+++ b/kernel/include/kernel/syscall.h
@@ -5,6 +5,6 @@
 #include <kernel/idt.h>
 
 void syscall_handler (registers_t* registers);
-void __init_syscalls__ (void);
+void init_syscalls (void);
 
 #endif

--- a/kernel/include/liballoc/liballoc.h
+++ b/kernel/include/liballoc/liballoc.h
@@ -31,7 +31,7 @@ extern "C" {
  * \return 0 if the lock was acquired successfully. Anything else is
  * failure.
  */
-extern int liballoc_lock ();
+extern int liballoc_lock (void);
 
 /** This function unlocks what was previously locked by the liballoc_lock
  * function.  If it disabled interrupts, it enables interrupts. If it
@@ -39,7 +39,7 @@ extern int liballoc_lock ();
  *
  * \return 0 if the lock was successfully released.
  */
-extern int liballoc_unlock ();
+extern int liballoc_unlock (void);
 
 /** This is the hook into the local system which allocates pages. It
  * accepts an integer parameter which is the number of pages

--- a/kernel/include/liballoc/liballoc.h
+++ b/kernel/include/liballoc/liballoc.h
@@ -63,7 +63,7 @@ extern int liballoc_free (void*, size_t);
 extern void* PREFIX (malloc) (size_t);		   ///< The standard function.
 extern void* PREFIX (realloc) (void*, size_t); ///< The standard function.
 extern void* PREFIX (calloc) (size_t, size_t); ///< The standard function.
-extern void PREFIX (free) (void*);			   ///< The standard function.
+extern void	 PREFIX (free) (void*);			   ///< The standard function.
 
 #ifdef __cplusplus
 }

--- a/kernel/include/memory.h
+++ b/kernel/include/memory.h
@@ -7,6 +7,6 @@
 void* memcpy (void*, const void*, size_t);
 void* memset (void*, int, size_t);
 void* memmove (void*, const void*, size_t);
-int memcmp (const void*, const void*, size_t);
+int	  memcmp (const void*, const void*, size_t);
 
 #endif

--- a/kernel/include/string.h
+++ b/kernel/include/string.h
@@ -6,9 +6,9 @@
 #include <stdint.h>
 
 size_t strlen (const char*);
-void itos (int32_t, char*, uint32_t);
-void ulitos (uint64_t, char*, uint32_t);
-int strcmp (const char* a, const char* b);
-char* strdup (const char* s);
+void   itos (int32_t, char*, uint32_t);
+void   ulitos (uint64_t, char*, uint32_t);
+int	   strcmp (const char* a, const char* b);
+char*  strdup (const char* s);
 
 #endif

--- a/kernel/include/string.h
+++ b/kernel/include/string.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+void   reverse (char* str);
 size_t strlen (const char*);
 void   itos (int32_t, char*, uint32_t);
 void   ulitos (uint64_t, char*, uint32_t);

--- a/kernel/src/kernel/console.c
+++ b/kernel/src/kernel/console.c
@@ -8,7 +8,7 @@
 #include <string.h>
 
 #define CONSOLE_HEIGHT 80
-#define CONSOLE_WIDTH 140
+#define CONSOLE_WIDTH  140
 
 bool PUTCH_UPDATE = false;
 

--- a/kernel/src/kernel/console.c
+++ b/kernel/src/kernel/console.c
@@ -62,7 +62,7 @@ Initialise the console with the default (classic) font
 @param	y_spc spacing between lines
 @param	font_size font size
 */
-void __init_console__ (size_t x_screen, size_t y_screen, size_t x_pad, size_t y_pad, size_t x_spc,
+void init_console (size_t x_screen, size_t y_screen, size_t x_pad, size_t y_pad, size_t x_spc,
 					   size_t y_spc, size_t font_size) {
 	x = x_screen - 2 * x_pad;
 	y = y_screen - 2 * y_pad;

--- a/kernel/src/kernel/console.c
+++ b/kernel/src/kernel/console.c
@@ -63,7 +63,7 @@ Initialise the console with the default (classic) font
 @param	font_size font size
 */
 void init_console (size_t x_screen, size_t y_screen, size_t x_pad, size_t y_pad, size_t x_spc,
-					   size_t y_spc, size_t font_size) {
+				   size_t y_spc, size_t font_size) {
 	x = x_screen - 2 * x_pad;
 	y = y_screen - 2 * y_pad;
 

--- a/kernel/src/kernel/console.c
+++ b/kernel/src/kernel/console.c
@@ -109,7 +109,7 @@ Register a character to the screen buffer.
 @param	rc character to register
 @param	index position to print it on
 */
-void registerChar (unsigned char rc, int index) {
+static void registerChar (unsigned char rc, int index) {
 	buffer[index] = rc;
 	colorbuffer[index] = color;
 }

--- a/kernel/src/kernel/console.c
+++ b/kernel/src/kernel/console.c
@@ -17,9 +17,9 @@ unsigned char bufferstr[CONSOLE_HEIGHT * CONSOLE_WIDTH] = {
 uint32_t colorbufferstr[CONSOLE_HEIGHT * CONSOLE_WIDTH] = {
 	0xffffff}; // TODO: replace this with malloc when implemented
 unsigned char* buffer = bufferstr;
-uint32_t* colorbuffer = colorbufferstr;
-size_t x, y, xs, ys, xsp, ysp, xc, yc, fs;
-size_t idx = 0;
+uint32_t*	   colorbuffer = colorbufferstr;
+size_t		   x, y, xs, ys, xsp, ysp, xc, yc, fs;
+size_t		   idx = 0;
 
 uint32_t color = 0xeeeeee;
 

--- a/kernel/src/kernel/console.c
+++ b/kernel/src/kernel/console.c
@@ -129,8 +129,7 @@ void putchar (unsigned char rc) {
 	}
 	registerChar (rc, idx);
 	idx++;
-	if (PUTCH_UPDATE)
-		update ();
+	if (PUTCH_UPDATE) update ();
 }
 
 /*!

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -148,7 +148,7 @@ void _start (void) {
 
 	printf ("\nInitramfs at 0x%llx, size %ld bytes\n", initramfs_addr, initramfs_size);
 
-	load_initramfs (initramfs_addr, (size_t)initramfs_size);
+	load_initramfs (initramfs_addr);
 
 	printf ("\nJumping to user land!\n");
 

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -33,9 +33,8 @@ uint64_t hhdm_base = 0;
 // Halt and catch fire function.
 static void hcf (void) {
 	asm ("cli");
-	for (;;) {
+	for (;;)
 		asm ("hlt");
-	}
 }
 
 __attribute__ ((noreturn)) void jump_to_usermode (uintptr_t entry_point, uintptr_t user_stack) {

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -26,6 +26,7 @@ extern volatile struct limine_memmap_request memmap_req;
 extern volatile struct limine_module_request mod_req;
 extern volatile struct limine_hhdm_request hhdm_req;
 
+struct limine_framebuffer* framebuffer = NULL;
 uint64_t hhdm_base = 0;
 
 // Halt and catch fire function.
@@ -63,49 +64,25 @@ __attribute__ ((noreturn)) void jump_to_usermode (uintptr_t entry_point, uintptr
 		;
 }
 
-/*!
-Entry point of kernel. Everything is set up here.
-*/
-void _start (void) {
-	// Ensure we got a framebuffer.
-	if (framebuffer_request.response == NULL ||
-		framebuffer_request.response->framebuffer_count < 1) {
+void get_limine_requests (void) {
+	// REQUIRED: framebuffer
+	if (framebuffer_request.response == NULL || framebuffer_request.response->framebuffer_count < 1)
 		hcf ();
-	}
+	framebuffer = framebuffer_request.response->framebuffers[0];
 
-	// Fetch the first framebuffer.
-	// Note: we assume the framebuffer model is RGB with 32-bit pixels.
-	struct limine_framebuffer* framebuffer = framebuffer_request.response->framebuffers[0];
-
-	asm ("cli");
-
-	init_gdt ();
-	init_pic ();
-	init_idt ();
-
-	asm ("sti");
-
-	init_serial ();
-
-	write_serial_str ("Hello from COS!\n");
-
-	init_graphics (framebuffer);
-	drawBorder (20);
-
-	init_console (framebuffer->width, framebuffer->height, 40, 40, 1, 1, 2);
-
-	// Check if we got a valid HHDM response.
-	if (hhdm_req.response != NULL) {
+	// REQUIRED: hhdm response
+	if (hhdm_req.response != NULL)
 		hhdm_base = hhdm_req.response->offset;
-	} else {
-		printf ("Error: did not receive HHDM address.\n\n");
+	else
 		hcf ();
-	}
 
-	init_memmgt (hhdm_base, memmap_req.response);
-	init_syscalls ();
-	init_handlers ();
+	// REQUIRED: modules (for initramfs)
+	if (mod_req.response == NULL || mod_req.response->module_count < 1)
+		hcf ();
+}
 
+void print_info (void) {
+	drawBorder (20);
 	set_color (0x44eeaa);
 
 	printf ("COS 0.0%d", 7);
@@ -127,18 +104,33 @@ void _start (void) {
 		printf ("\nSystem booted at time %ld.\n", boottime_req.response->boot_time);
 	} else
 		printf ("\nDid not receive boot time from Limine.\n");
+}
 
-	printf ("\n\n");
-	uint64_t cr3;
-	__asm__ volatile ("mov %%cr3, %0" : "=r"(cr3));
-	cr3 = cr3 & 0xFFFFFFFFFF000;
+/*!
+Entry point of kernel. Everything is set up here.
+*/
+void _start (void) {
 
-	printf ("CR3: %lx\n", cr3);
+	asm ("cli");
 
-	if (mod_req.response == NULL || mod_req.response->module_count < 1) {
-		printf ("Error: no modules loaded.\n");
-		hcf ();
-	}
+	init_gdt ();
+	init_pic ();
+	init_idt ();
+
+	asm ("sti");
+
+	init_serial ();
+	write_serial_str ("Hello from COS!\n");
+
+	get_limine_requests ();
+
+	init_memmgt (hhdm_base, memmap_req.response);
+	init_syscalls ();
+	init_handlers ();
+
+	init_graphics (framebuffer);
+	init_console (framebuffer->width, framebuffer->height, 40, 40, 1, 1, 2);
+	print_info ();
 
 	struct limine_file* initramfs = mod_req.response->modules[0];
 	void* initramfs_addr = initramfs->address;

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -70,12 +70,10 @@ void get_limine_requests (void) {
 		hcf ();
 
 	// REQUIRED: hhdm response
-	if (hhdm_req.response == NULL)
-		hcf ();
+	if (hhdm_req.response == NULL) hcf ();
 
 	// REQUIRED: modules (for initramfs)
-	if (mod_req.response == NULL || mod_req.response->module_count < 1)
-		hcf ();
+	if (mod_req.response == NULL || mod_req.response->module_count < 1) hcf ();
 
 	// set the values received from limine
 	framebuffer = framebuffer_request.response->framebuffers[0];

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -19,16 +19,16 @@
 
 #define FONT_SIZE 2
 
-extern volatile struct limine_framebuffer_request framebuffer_request;
+extern volatile struct limine_framebuffer_request	  framebuffer_request;
 extern volatile struct limine_bootloader_info_request bootinfo_req;
-extern volatile struct limine_boot_time_request boottime_req;
-extern volatile struct limine_memmap_request memmap_req;
-extern volatile struct limine_module_request mod_req;
-extern volatile struct limine_hhdm_request hhdm_req;
+extern volatile struct limine_boot_time_request		  boottime_req;
+extern volatile struct limine_memmap_request		  memmap_req;
+extern volatile struct limine_module_request		  mod_req;
+extern volatile struct limine_hhdm_request			  hhdm_req;
 
 struct limine_framebuffer* framebuffer = NULL;
-struct limine_file* initramfs = NULL;
-uint64_t hhdm_base = 0;
+struct limine_file*		   initramfs = NULL;
+uint64_t				   hhdm_base = 0;
 
 // Halt and catch fire function.
 static void hcf (void) {
@@ -132,7 +132,7 @@ void _start (void) {
 	init_console (framebuffer->width, framebuffer->height, 40, 40, 1, 1, 2);
 	print_info ();
 
-	void* initramfs_addr = initramfs->address;
+	void*	 initramfs_addr = initramfs->address;
 	uint64_t initramfs_size = initramfs->size;
 
 	printf ("\nInitramfs at 0x%llx, size %ld bytes\n", initramfs_addr, initramfs_size);

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -30,6 +30,9 @@ struct limine_framebuffer* framebuffer = NULL;
 struct limine_file*		   initramfs = NULL;
 uint64_t				   hhdm_base = 0;
 
+// Declaration of kernel entry point
+void _start (void);
+
 // Halt and catch fire function.
 static void hcf (void) {
 	asm ("cli");
@@ -37,7 +40,8 @@ static void hcf (void) {
 		asm ("hlt");
 }
 
-__attribute__ ((noreturn)) void jump_to_usermode (uintptr_t entry_point, uintptr_t user_stack) {
+__attribute__ ((noreturn)) static void jump_to_usermode (uintptr_t entry_point,
+														 uintptr_t user_stack) {
 	__asm__ volatile (
 		"cli \n\t"			   // 1. Disable interrupts while swapping states
 		"mov $0x3B, %%ax \n\t" // 2. Load User Data Segment descriptor (0x38 | 3 = 0x3B)
@@ -64,7 +68,7 @@ __attribute__ ((noreturn)) void jump_to_usermode (uintptr_t entry_point, uintptr
 		;
 }
 
-void get_limine_requests (void) {
+static void get_limine_requests (void) {
 	// REQUIRED: framebuffer
 	if (framebuffer_request.response == NULL || framebuffer_request.response->framebuffer_count < 1)
 		hcf ();
@@ -81,7 +85,7 @@ void get_limine_requests (void) {
 	initramfs = mod_req.response->modules[0];
 }
 
-void print_info (void) {
+static void print_info (void) {
 	drawBorder (20);
 	set_color (0x44eeaa);
 

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -27,6 +27,7 @@ extern volatile struct limine_module_request mod_req;
 extern volatile struct limine_hhdm_request hhdm_req;
 
 struct limine_framebuffer* framebuffer = NULL;
+struct limine_file* initramfs = NULL;
 uint64_t hhdm_base = 0;
 
 // Halt and catch fire function.
@@ -68,17 +69,19 @@ void get_limine_requests (void) {
 	// REQUIRED: framebuffer
 	if (framebuffer_request.response == NULL || framebuffer_request.response->framebuffer_count < 1)
 		hcf ();
-	framebuffer = framebuffer_request.response->framebuffers[0];
 
 	// REQUIRED: hhdm response
-	if (hhdm_req.response != NULL)
-		hhdm_base = hhdm_req.response->offset;
-	else
+	if (hhdm_req.response == NULL)
 		hcf ();
 
 	// REQUIRED: modules (for initramfs)
 	if (mod_req.response == NULL || mod_req.response->module_count < 1)
 		hcf ();
+
+	// set the values received from limine
+	framebuffer = framebuffer_request.response->framebuffers[0];
+	hhdm_base = hhdm_req.response->offset;
+	initramfs = mod_req.response->modules[0];
 }
 
 void print_info (void) {
@@ -132,7 +135,6 @@ void _start (void) {
 	init_console (framebuffer->width, framebuffer->height, 40, 40, 1, 1, 2);
 	print_info ();
 
-	struct limine_file* initramfs = mod_req.response->modules[0];
 	void* initramfs_addr = initramfs->address;
 	uint64_t initramfs_size = initramfs->size;
 

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -82,19 +82,19 @@ void _start (void) {
 	gdt_init ();
 	tss_init ();
 
-	__init_pic__ ();
-	__init_idt__ ();
+	init_pic ();
+	init_idt ();
 
 	asm ("sti");
 
-	__init_serial__ ();
+	init_serial ();
 
 	write_serial_str ("Hello from COS!\n");
 
-	__init_graphics__ (framebuffer);
+	init_graphics (framebuffer);
 	drawBorder (20);
 
-	__init_console__ (framebuffer->width, framebuffer->height, 40, 40, 1, 1, 2);
+	init_console (framebuffer->width, framebuffer->height, 40, 40, 1, 1, 2);
 
 	// Check if we got a valid HHDM response.
 	if (hhdm_req.response != NULL) {
@@ -104,9 +104,9 @@ void _start (void) {
 		hcf ();
 	}
 
-	__init_memmgt__ (hhdm_base, memmap_req.response);
-	__init_syscalls__ ();
-	__init_handlers__ ();
+	init_memmgt (hhdm_base, memmap_req.response);
+	init_syscalls ();
+	init_handlers ();
 
 	set_color (0x44eeaa);
 

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -79,9 +79,7 @@ void _start (void) {
 
 	asm ("cli");
 
-	gdt_init ();
-	tss_init ();
-
+	init_gdt ();
 	init_pic ();
 	init_idt ();
 

--- a/kernel/src/kernel/fs/cpio.c
+++ b/kernel/src/kernel/fs/cpio.c
@@ -45,15 +45,12 @@ static void* jump_next_file (void* pos) {
 	uint64_t filesize = hex_to_u64 (header->c_filesize);
 
 	pos += sizeof (cpio_newc_header_t);
-	if (memcmp (pos, "TRAILER!!!", 11) == 0)
-		return NULL;
+	if (memcmp (pos, "TRAILER!!!", 11) == 0) return NULL;
 
 	pos += namesize;
-	if ((uint64_t)pos % 4)
-		pos += 4 - ((uint64_t)pos % 4);
+	if ((uint64_t)pos % 4) pos += 4 - ((uint64_t)pos % 4);
 	pos += filesize;
-	if ((uint64_t)pos % 4)
-		pos += 4 - ((uint64_t)pos % 4);
+	if ((uint64_t)pos % 4) pos += 4 - ((uint64_t)pos % 4);
 
 	return pos;
 }
@@ -70,10 +67,8 @@ static inode* create_folders_if_noexist (char* arg_abspath) {
 	while (idx && *idx != 0) {
 		while (*idx == '/')
 			idx++;
-		if (*idx == 0)
-			break;
-		if (parent == NULL)
-			break;
+		if (*idx == 0) break;
+		if (parent == NULL) break;
 		char* next_slash = idx + 1;
 
 		while (*next_slash != 0 && *next_slash != '/')
@@ -104,28 +99,24 @@ static inode* create_folders_if_noexist (char* arg_abspath) {
 }
 
 static void parse_file_to_inode (cpio_newc_header_t* header) {
-	if (header == NULL)
-		return;
+	if (header == NULL) return;
 
 	uint64_t namesize = hex_to_u64 (header->c_namesize);
 	uint64_t filesize = hex_to_u64 (header->c_filesize);
 	uint64_t filemode = hex_to_u64 (header->c_mode);
 	uint64_t filetype = filemode & 0170000;
 
-	if (namesize == 0)
-		return;
+	if (namesize == 0) return;
 
 	char* filename = kmalloc (namesize);
 	memcpy ((void*)filename, (void*)(header + 1), namesize);
 	filename[namesize - 1] = 0; // enforce string in case corrupt
 
-	if (strcmp (filename, "TRAILER!!!") == 0 || strcmp (filename, ".") == 0)
-		goto cleanup;
+	if (strcmp (filename, "TRAILER!!!") == 0 || strcmp (filename, ".") == 0) goto cleanup;
 
 	if (filetype == C_ISDIR) {
 		inode* directory = create_folders_if_noexist (filename);
-		if (!directory)
-			goto cleanup;
+		if (!directory) goto cleanup;
 	}
 
 	if (filetype == C_ISREG) {
@@ -134,28 +125,24 @@ static void parse_file_to_inode (cpio_newc_header_t* header) {
 		while (last_slash >= filename && *last_slash != '/')
 			last_slash--;
 
-		if (last_slash < filename)
-			goto cleanup;
+		if (last_slash < filename) goto cleanup;
 		*last_slash = 0;
 
 		inode* parent_directory = create_folders_if_noexist (filename);
 		inode* new_file = NULL;
 		*last_slash = '/';
 
-		if (!parent_directory)
-			goto cleanup;
+		if (!parent_directory) goto cleanup;
 
 		if (*(last_slash + 1) != 0) {
 			int error = do_create (last_slash + 1, &new_file, parent_directory);
-			if (error != 0)
-				goto cleanup;
+			if (error != 0) goto cleanup;
 		}
 
 		if (new_file) {
 			void* data = (void*)(header + 1);
 			data += namesize;
-			if ((uint64_t)data % 4)
-				data += 4 - ((uint64_t)data % 4);
+			if ((uint64_t)data % 4) data += 4 - ((uint64_t)data % 4);
 
 			new_file->i_pvt = kmalloc (filesize);
 			new_file->i_sz = filesize;
@@ -227,12 +214,9 @@ int create (char* filename, inode** result, inode* root) {
 }
 
 int lookup (char* filename, inode** result, inode* root) {
-	if (!root)
-		return -ENOROOT;
-	if (!filename || filename[0] == '\0')
-		return -EINVARG;
-	if (root->i_type != DIRECTORY)
-		return -EINVPATH;
+	if (!root) return -ENOROOT;
+	if (!filename || filename[0] == '\0') return -EINVARG;
+	if (root->i_type != DIRECTORY) return -EINVPATH;
 
 	// case '.'
 	if (strcmp (filename, ".") == 0) {
@@ -241,20 +225,17 @@ int lookup (char* filename, inode** result, inode* root) {
 	}
 
 	// case '*' , root is empty
-	if (!root->i_pvt)
-		return -EPNOEXIST;
+	if (!root->i_pvt) return -EPNOEXIST;
 
 	dir_content_t* dir_content = (dir_content_t*)root->i_pvt;
 
 	// case '*' , root is empty
-	if (!dir_content->d_children)
-		return -EPNOEXIST;
+	if (!dir_content->d_children) return -EPNOEXIST;
 
 	for (uint64_t i = 0; i < dir_content->d_count; i++) {
 		child_t* d_child = &dir_content->d_children[i];
 		// invalid child ; continue searching
-		if (!d_child->c_inode || !d_child->c_name)
-			continue;
+		if (!d_child->c_inode || !d_child->c_name) continue;
 
 		if (strcmp (d_child->c_name, filename) == 0) {
 			// case '*'

--- a/kernel/src/kernel/fs/cpio.c
+++ b/kernel/src/kernel/fs/cpio.c
@@ -11,14 +11,14 @@
 #define C_ISLNK 0120000
 
 static uint64_t inode_no;
-static inode* root_inode;
+static inode*	root_inode;
 
 static inode_operations i_ops = {.lookup = lookup, .mkdir = mkdir, .create = create};
 
 static uint64_t hex_to_u64 (const char hex[8]) {
 	uint64_t val = 0;
 	for (int i = 0; i < 8; i++) {
-		char c = hex[i];
+		char	c = hex[i];
 		uint8_t digit;
 		if (c >= '0' && c <= '9')
 			digit = c - '0';
@@ -60,7 +60,7 @@ static inode* create_folders_if_noexist (char* arg_abspath) {
 	memcpy ((void*)abspath, arg_abspath, strlen (arg_abspath));
 	abspath[strlen (arg_abspath)] = 0;
 
-	char* idx = abspath;
+	char*  idx = abspath;
 	inode* parent = root_inode;
 	inode* child = NULL;
 
@@ -121,7 +121,7 @@ static void parse_file_to_inode (cpio_newc_header_t* header) {
 
 	if (filetype == C_ISREG) {
 		size_t path_len = strlen (filename);
-		char* last_slash = &filename[path_len - 1];
+		char*  last_slash = &filename[path_len - 1];
 		while (last_slash >= filename && *last_slash != '/')
 			last_slash--;
 
@@ -176,7 +176,8 @@ int mkdir (char* dirname, inode** result, inode* root) {
 
 	// construct parent replacement structures
 	dir_content_t* parent_pvt = (dir_content_t*)root->i_pvt;
-	child_t* new_parent_children = kmalloc ((parent_pvt->d_count + 1) * sizeof (child_t));
+	child_t*	   new_parent_children = kmalloc ((parent_pvt->d_count + 1) * sizeof (child_t));
+
 	memcpy (new_parent_children, parent_pvt->d_children, parent_pvt->d_count * sizeof (child_t));
 	new_parent_children[parent_pvt->d_count].c_inode = new_dir;
 	new_parent_children[parent_pvt->d_count].c_name = strdup (dirname);
@@ -199,7 +200,8 @@ int create (char* filename, inode** result, inode* root) {
 
 	// construct parent replacement structures
 	dir_content_t* parent_pvt = (dir_content_t*)root->i_pvt;
-	child_t* new_parent_children = kmalloc ((parent_pvt->d_count + 1) * sizeof (child_t));
+	child_t*	   new_parent_children = kmalloc ((parent_pvt->d_count + 1) * sizeof (child_t));
+
 	memcpy (new_parent_children, parent_pvt->d_children, parent_pvt->d_count * sizeof (child_t));
 	new_parent_children[parent_pvt->d_count].c_inode = new_file;
 	new_parent_children[parent_pvt->d_count].c_name = strdup (filename);

--- a/kernel/src/kernel/fs/cpio.c
+++ b/kernel/src/kernel/fs/cpio.c
@@ -269,7 +269,7 @@ int lookup (char* filename, inode** result, inode* root) {
 	return -EPNOEXIST;
 }
 
-void load_initramfs (void* pos, size_t size) {
+void load_initramfs (void* pos) {
 	root_inode = kmalloc (sizeof (inode));
 	memset ((void*)root_inode, 0, sizeof (inode));
 	root_inode->i_type = DIRECTORY;

--- a/kernel/src/kernel/fs/cpio.c
+++ b/kernel/src/kernel/fs/cpio.c
@@ -87,17 +87,15 @@ static inode* create_folders_if_noexist (char* arg_abspath) {
 			*next_slash = actual_char;
 			idx = next_slash;
 			continue;
+		} else if (parent->i_iops->mkdir (idx, &child, parent) == 0) {
+			parent = child;
+			child = NULL;
+			*next_slash = actual_char;
+			idx = next_slash;
+			continue;
 		} else {
-			if (parent->i_iops->mkdir (idx, &child, parent) == 0) {
-				parent = child;
-				child = NULL;
-				*next_slash = actual_char;
-				idx = next_slash;
-				continue;
-			} else {
-				parent = NULL;
-				idx = NULL;
-			}
+			parent = NULL;
+			idx = NULL;
 		}
 	}
 

--- a/kernel/src/kernel/fs/vfs.c
+++ b/kernel/src/kernel/fs/vfs.c
@@ -40,7 +40,7 @@ int do_mkdir (char* dirname, inode** result, inode* parent) {
 
 	// case dirname already exists
 	inode* lookup_result = NULL;
-	int error = parent->i_iops->lookup (dirname, &lookup_result, parent);
+	int	   error = parent->i_iops->lookup (dirname, &lookup_result, parent);
 	if (error == 0) return -EPEXISTS;
 	if (error != -EPNOEXIST) return error;
 
@@ -73,7 +73,7 @@ int do_create (char* filename, inode** result, inode* parent) {
 
 	// case filename already exists
 	inode* lookup_result = NULL;
-	int error = parent->i_iops->lookup (filename, &lookup_result, parent);
+	int	   error = parent->i_iops->lookup (filename, &lookup_result, parent);
 	if (error == 0) return -EPEXISTS;
 	if (error != -EPNOEXIST) return error;
 
@@ -142,7 +142,7 @@ int do_lookup (char* filename, inode** result, inode* root) {
 
 	// case '/*', root is a directory, * may or may not be a file -- look it up
 	inode* target_inode = NULL;
-	int error = root->i_iops->lookup (target_name, &target_inode, root);
+	int	   error = root->i_iops->lookup (target_name, &target_inode, root);
 
 	kfree (target_name);
 

--- a/kernel/src/kernel/fs/vfs.c
+++ b/kernel/src/kernel/fs/vfs.c
@@ -9,8 +9,7 @@
 
 static bool filename_has_invalid_chars (char* filename) {
 	while (*filename != 0) {
-		if (*filename == '/' || *filename < (char)32)
-			return true;
+		if (*filename == '/' || *filename < (char)32) return true;
 		filename++;
 	}
 	return false;
@@ -25,32 +24,25 @@ static bool filename_has_invalid_chars (char* filename) {
  */
 int do_mkdir (char* dirname, inode** result, inode* parent) {
 	// case parent not provided
-	if (!parent)
-		return -EINVARG;
+	if (!parent) return -EINVARG;
 
 	// case parent is not a directory
-	if (parent->i_type != DIRECTORY)
-		return -EINVARG;
+	if (parent->i_type != DIRECTORY) return -EINVARG;
 
 	// case dirname is absent or 0 chars long
-	if (!dirname || *dirname == 0)
-		return -EINVARG;
+	if (!dirname || *dirname == 0) return -EINVARG;
 
 	// case dirname has invalid characters
-	if (filename_has_invalid_chars (dirname))
-		return -EINVARG;
+	if (filename_has_invalid_chars (dirname)) return -EINVARG;
 
 	// case dirname is '.' or '..'
-	if (strcmp (dirname, ".") == 0 || strcmp (dirname, "..") == 0)
-		return -EINVARG;
+	if (strcmp (dirname, ".") == 0 || strcmp (dirname, "..") == 0) return -EINVARG;
 
 	// case dirname already exists
 	inode* lookup_result = NULL;
 	int error = parent->i_iops->lookup (dirname, &lookup_result, parent);
-	if (error == 0)
-		return -EPEXISTS;
-	if (error != -EPNOEXIST)
-		return error;
+	if (error == 0) return -EPEXISTS;
+	if (error != -EPNOEXIST) return error;
 
 	// case dirname valid, parent exists and dirname does not yet
 	return parent->i_iops->mkdir (dirname, result, parent);
@@ -65,32 +57,25 @@ int do_mkdir (char* dirname, inode** result, inode* parent) {
  */
 int do_create (char* filename, inode** result, inode* parent) {
 	// case parent not provided
-	if (!parent)
-		return -EINVARG;
+	if (!parent) return -EINVARG;
 
 	// case parent is not a directory
-	if (parent->i_type != DIRECTORY)
-		return -EINVARG;
+	if (parent->i_type != DIRECTORY) return -EINVARG;
 
 	// case filename is absent or 0 chars long
-	if (!filename || *filename == 0)
-		return -EINVARG;
+	if (!filename || *filename == 0) return -EINVARG;
 
 	// case filename has invalid characters
-	if (filename_has_invalid_chars (filename))
-		return -EINVARG;
+	if (filename_has_invalid_chars (filename)) return -EINVARG;
 
 	// case filename is '.' or '..'
-	if (strcmp (filename, ".") == 0 || strcmp (filename, "..") == 0)
-		return -EINVARG;
+	if (strcmp (filename, ".") == 0 || strcmp (filename, "..") == 0) return -EINVARG;
 
 	// case filename already exists
 	inode* lookup_result = NULL;
 	int error = parent->i_iops->lookup (filename, &lookup_result, parent);
-	if (error == 0)
-		return -EPEXISTS;
-	if (error != -EPNOEXIST)
-		return error;
+	if (error == 0) return -EPEXISTS;
+	if (error != -EPNOEXIST) return error;
 
 	// case filename valid, parent exists and dirname does not yet
 	return parent->i_iops->create (filename, result, parent);
@@ -106,21 +91,17 @@ int do_create (char* filename, inode** result, inode* parent) {
  */
 int do_lookup (char* filename, inode** result, inode* root) {
 	// case root not provided
-	if (!root)
-		return -ENOROOT;
+	if (!root) return -ENOROOT;
 
 	// case filename is absent or 0 chars long
-	if (!filename || filename[0] == 0)
-		return -EINVARG;
+	if (!filename || filename[0] == 0) return -EINVARG;
 
 	// case filename is not absolute
 	// TODO: allow relative paths like this?
-	if (filename[0] != '/')
-		return -ENEEDABS;
+	if (filename[0] != '/') return -ENEEDABS;
 
 	// case '/*', root is a file
-	if (root->i_type != DIRECTORY)
-		return -EINVPATH;
+	if (root->i_type != DIRECTORY) return -EINVPATH;
 
 	// case when filename starts with multiple slashes
 	// should not access null because above checks guarantee at least one character
@@ -178,8 +159,7 @@ int do_lookup (char* filename, inode** result, inode* root) {
 	}
 
 	// case '/path/*', 'path' exists but is a file (invalid recursion)
-	if (target_inode->i_type == EFILE)
-		return -EINVPATH;
+	if (target_inode->i_type == EFILE) return -EINVPATH;
 
 	// case '/path/*', 'path' exists and is a directory
 	return do_lookup (next_slash, result, target_inode);

--- a/kernel/src/kernel/gdt.c
+++ b/kernel/src/kernel/gdt.c
@@ -20,8 +20,8 @@ gdt_t gdt = {
 gdt_pointer_t gdt_pointer;
 tss_t tss;
 
-void gdt_init (void) {
-	tss_init ();
+void init_gdt (void) {
+	init_tss ();
 
 	gdt_pointer.size = sizeof (gdt_t) - 1;
 	gdt_pointer.offset = (uint64_t)&gdt;
@@ -30,7 +30,7 @@ void gdt_init (void) {
 	tss_flush ();
 }
 
-void tss_init (void) {
+void init_tss (void) {
 	memset (&tss, 0, sizeof (tss));
 
 	tss.rsp[0] = (uintptr_t)stack;

--- a/kernel/src/kernel/gdt.c
+++ b/kernel/src/kernel/gdt.c
@@ -18,7 +18,7 @@ gdt_t gdt = {
 };
 
 gdt_pointer_t gdt_pointer;
-tss_t tss;
+tss_t		  tss;
 
 void init_gdt (void) {
 	init_tss ();

--- a/kernel/src/kernel/graphics.c
+++ b/kernel/src/kernel/graphics.c
@@ -3,8 +3,8 @@
 #include <stdint.h>
 
 static struct limine_framebuffer* framebuffer;
-static size_t frmw, frmh;
-uint32_t* fb_ptr;
+static size_t					  frmw, frmh;
+uint32_t*						  fb_ptr;
 
 /*!
 Initialise the graphics interface.

--- a/kernel/src/kernel/graphics.c
+++ b/kernel/src/kernel/graphics.c
@@ -74,10 +74,9 @@ Draw a white border around the screen.
 @param	padding pixels to leave around the edges
 */
 void drawBorder (size_t padding) {
-	for (size_t i = 0; i < frmw * frmh; i++) {
+	for (size_t i = 0; i < frmw * frmh; i++)
 		if (i % frmw == padding || i % frmw == frmw - padding)
 			fb_ptr[i] = 0xffffff;
 		else if (i / frmw == padding || i / frmw == frmh - padding)
 			fb_ptr[i] = 0xffffff;
-	}
 }

--- a/kernel/src/kernel/graphics.c
+++ b/kernel/src/kernel/graphics.c
@@ -11,7 +11,7 @@ Initialise the graphics interface.
 
 @param	buf	pointer to framebuffer passed by lumine
 */
-void __init_graphics__ (struct limine_framebuffer* buf) {
+void init_graphics (struct limine_framebuffer* buf) {
 	framebuffer = buf;
 	frmw = framebuffer->width;
 	frmh = framebuffer->height;

--- a/kernel/src/kernel/graphics.c
+++ b/kernel/src/kernel/graphics.c
@@ -45,7 +45,7 @@ Place a pixel on the screen.
 @param	x x-position
 @param	y y-position
 */
-void putPixel (uint32_t color, int x, int y) { fb_ptr[postoi (x, y)] = color; }
+static void putPixel (uint32_t color, int x, int y) { fb_ptr[postoi (x, y)] = color; }
 
 /*!
 Place a character on the screen

--- a/kernel/src/kernel/handlers.c
+++ b/kernel/src/kernel/handlers.c
@@ -7,4 +7,4 @@ void handle_gpf (registers_t* registers) {
 		;
 }
 
-void __init_handlers__ (void) { idt_register_handler (0xD, handle_gpf); }
+void init_handlers (void) { idt_register_handler (0xD, handle_gpf); }

--- a/kernel/src/kernel/hardfonts/classic.c
+++ b/kernel/src/kernel/hardfonts/classic.c
@@ -781,7 +781,6 @@ Return the glyph for a certain character from the classic font
 @return	pointer to 5x8 glyph
 */
 unsigned char* glyph (char index) {
-	if (index < 32)
-		return &__classic_font__[0][0][0];
+	if (index < 32) return &__classic_font__[0][0][0];
 	return &__classic_font__[index - 32][0][0];
 }

--- a/kernel/src/kernel/hardfonts/classic.c
+++ b/kernel/src/kernel/hardfonts/classic.c
@@ -1,3 +1,4 @@
+#include <kernel/hardfonts/classic.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/kernel/src/kernel/hw/pic.c
+++ b/kernel/src/kernel/hw/pic.c
@@ -19,8 +19,7 @@
 #define CASCADE_IRQ 2
 
 inline void pic_send_eoi (uint8_t irq) {
-	if (irq >= 8)
-		outb (PIC2_COMMAND, PIC_EOI);
+	if (irq >= 8) outb (PIC2_COMMAND, PIC_EOI);
 	outb (PIC1_COMMAND, PIC_EOI);
 }
 

--- a/kernel/src/kernel/hw/pic.c
+++ b/kernel/src/kernel/hw/pic.c
@@ -73,4 +73,4 @@ void pic_clr_mask (uint8_t irq_line) {
 	}
 }
 
-void __init_pic__ (void) { pic_remap (0x20, 0x28); }
+void init_pic (void) { pic_remap (0x20, 0x28); }

--- a/kernel/src/kernel/hw/pic.c
+++ b/kernel/src/kernel/hw/pic.c
@@ -4,17 +4,17 @@
 // See: https://wiki.osdev.org/8259_PIC
 // TODO: Move to APIC (long-term)
 
-#define ICW1_ICW4 0x01		/* Indicates that ICW4 will be present */
-#define ICW1_SINGLE 0x02	/* Single (cascade) mode */
+#define ICW1_ICW4	   0x01 /* Indicates that ICW4 will be present */
+#define ICW1_SINGLE	   0x02 /* Single (cascade) mode */
 #define ICW1_INTERVAL4 0x04 /* Call address interval 4 (8) */
-#define ICW1_LEVEL 0x08		/* Level triggered (edge) mode */
-#define ICW1_INIT 0x10		/* Initialization - required! */
+#define ICW1_LEVEL	   0x08 /* Level triggered (edge) mode */
+#define ICW1_INIT	   0x10 /* Initialization - required! */
 
-#define ICW4_8086 0x01		 /* 8086/88 (MCS-80/85) mode */
-#define ICW4_AUTO 0x02		 /* Auto (normal) EOI */
-#define ICW4_BUF_SLAVE 0x08	 /* Buffered mode/slave */
+#define ICW4_8086		0x01 /* 8086/88 (MCS-80/85) mode */
+#define ICW4_AUTO		0x02 /* Auto (normal) EOI */
+#define ICW4_BUF_SLAVE	0x08 /* Buffered mode/slave */
 #define ICW4_BUF_MASTER 0x0C /* Buffered mode/master */
-#define ICW4_SFNM 0x10		 /* Special fully nested (not) */
+#define ICW4_SFNM		0x10 /* Special fully nested (not) */
 
 #define CASCADE_IRQ 2
 

--- a/kernel/src/kernel/idt.c
+++ b/kernel/src/kernel/idt.c
@@ -6,12 +6,14 @@
 __attribute__ ((aligned (0x10))) static idt_entry_t idt[256];
 
 static idtr_t idtr;
-
 irq_handler_t interrupt_handlers[256];
+extern void*  isr_stub_table[];
 
-extern void* isr_stub_table[];
+// Declaration of handler for internal use only
+void kernel_dispatch_interrupt (registers_t* registers);
 
-void idt_set_gate (uint8_t vector, void* isr, uint8_t gate_type, uint8_t dpl, uint8_t present) {
+static void idt_set_gate (uint8_t vector, void* isr, uint8_t gate_type, uint8_t dpl,
+						  uint8_t present) {
 	idt_entry_t* descriptor = &idt[vector];
 
 	descriptor->offset_1 = (uint64_t)isr & 0xFFFF;

--- a/kernel/src/kernel/idt.c
+++ b/kernel/src/kernel/idt.c
@@ -99,7 +99,7 @@ void idt_set_flags (int vector, uint8_t gate_type, uint8_t dpl, uint8_t ist) {
 	descriptor->ist = ist;
 }
 
-void __init_idt__ (void) {
+void init_idt (void) {
 	idtr.size = (uint16_t)(sizeof (idt_entry_t) * 256) - 1;
 	idtr.offset = (uint64_t)&idt[0];
 

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -56,8 +56,7 @@ inline void* vaddr_t_to_ptr (vaddr_t* virtual_addr) {
 					   ((uint64_t)virtual_addr->pd_index << 21) |
 					   ((uint64_t)virtual_addr->pt_index << 12) | (uint64_t)virtual_addr->offset;
 
-	if (ptr_64t & (1ULL << 47))
-		ptr_64t |= 0xFFFF000000000000ULL;
+	if (ptr_64t & (1ULL << 47)) ptr_64t |= 0xFFFF000000000000ULL;
 	return (void*)ptr_64t;
 }
 
@@ -96,10 +95,8 @@ static inline void bitmap_clear_bit (uint64_t page_idx) {
  * @return base physical address of allocated frames
  */
 paddr_t alloc_ppages (uint64_t count) {
-	if (count == 0)
-		return NULL;
-	if (bitmap.pages_used + count > bitmap.pages_maxlen)
-		return NULL;
+	if (count == 0) return NULL;
+	if (bitmap.pages_used + count > bitmap.pages_maxlen) return NULL;
 
 	uint64_t current_streak = 0;
 	uint64_t start_idx = 0;
@@ -111,8 +108,7 @@ paddr_t alloc_ppages (uint64_t count) {
 		}
 
 		if ((bitmap.map[i / 8] & (1 << (i % 8))) == 0) {
-			if (current_streak == 0)
-				start_idx = i;
+			if (current_streak == 0) start_idx = i;
 			current_streak++;
 
 			if (current_streak == count) {
@@ -182,8 +178,7 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 		struct limine_memmap_entry* entry = memmap_response->entries[i];
 		if (entry->type == LIMINE_MEMMAP_USABLE) {
 			uint64_t top = entry->base + entry->length;
-			if (top > addr_limit)
-				addr_limit = top;
+			if (top > addr_limit) addr_limit = top;
 		}
 	}
 
@@ -221,8 +216,7 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 		if (entry->type == LIMINE_MEMMAP_USABLE) {
 			for (uint64_t p = entry->base / PAGE_SIZE;
 				 p < (entry->base + entry->length) / PAGE_SIZE; p++) {
-				if (p < bitmap_fst_page || p >= bitmap_lst_page)
-					bitmap_clear_bit (p);
+				if (p < bitmap_fst_page || p >= bitmap_lst_page) bitmap_clear_bit (p);
 			}
 		}
 	}
@@ -258,8 +252,7 @@ static bool is_vaddr_t_lt (vaddr_t* a, vaddr_t* b) {
 	if (a->pml4_index == b->pml4_index) {
 		if (a->pdpt_index == b->pdpt_index) {
 			if (a->pd_index == b->pd_index) {
-				if (a->pt_index == b->pt_index)
-					return a->offset < b->offset;
+				if (a->pt_index == b->pt_index) return a->offset < b->offset;
 				return a->pt_index < b->pt_index;
 			}
 			return a->pd_index < b->pd_index;
@@ -316,8 +309,7 @@ static void alloc_all_vpages_in_range (vaddr_t first, vaddr_t last, paddr_t base
 		pt_entry->us = user;
 		phys_base_track += PAGE_SIZE;
 
-		if (!is_vaddr_t_lt (&current, &last))
-			break;
+		if (!is_vaddr_t_lt (&current, &last)) break;
 
 		current.pt_index++;
 		if (current.pt_index >= 512) {
@@ -340,8 +332,7 @@ void* alloc_vpages (size_t req_count, bool user) {
 	// all memory allocations are currently under one pml4 entry. this is 512 gb of memory, which
 	// should be plenty for literally any use case of COS.
 	pml4t_entry_t* pml4t_entry = &pml4_base_ptr[1];
-	if (!pml4t_entry->present)
-		return NULL;
+	if (!pml4t_entry->present) return NULL;
 
 	size_t count_so_far = 0;
 	uint64_t start_page_idx = 0;
@@ -357,8 +348,7 @@ void* alloc_vpages (size_t req_count, bool user) {
 
 		if (!pdpt_entry->present) {
 			// we found 512*512 consecutive free pages!
-			if (count_so_far == 0)
-				start_page_idx = i;
+			if (count_so_far == 0) start_page_idx = i;
 			uint64_t pages_left = 512ull * 512ull - (i % (512ull * 512ull)); // just in case
 
 			if (count_so_far + pages_left >= req_count) {
@@ -376,8 +366,7 @@ void* alloc_vpages (size_t req_count, bool user) {
 
 		if (!pd_entry->present) {
 			// we found 512 consecutive free pages!
-			if (count_so_far == 0)
-				start_page_idx = i;
+			if (count_so_far == 0) start_page_idx = i;
 			uint64_t pages_left = 512ull - (i % 512ull); // just in case
 
 			if (count_so_far + pages_left >= req_count) {
@@ -397,19 +386,16 @@ void* alloc_vpages (size_t req_count, bool user) {
 			count_so_far = 0;
 			i++;
 		} else {
-			if (count_so_far == 0)
-				start_page_idx = i;
+			if (count_so_far == 0) start_page_idx = i;
 			count_so_far++;
-			if (count_so_far == req_count)
-				break;
+			if (count_so_far == req_count) break;
 			i++;
 		}
 	}
 
 	if (count_so_far == req_count) {
 		paddr_t base_physical = alloc_ppages (req_count);
-		if (base_physical == NULL)
-			return NULL; // no more physical memory
+		if (base_physical == NULL) return NULL; // no more physical memory
 
 		vaddr_t first_vaddr = {1, (start_page_idx >> 18) & 0x1FF, (start_page_idx >> 9) & 0x1FF,
 							   start_page_idx & 0x1FF, 0};
@@ -438,8 +424,7 @@ void* alloc_vpage (bool user) { return alloc_vpages (1, user); }
 static bool is_table_empty (void* table_vaddr) {
 	uint64_t* entries = (uint64_t*)table_vaddr;
 	for (int i = 0; i < 512; i++)
-		if (entries[i] & 1)
-			return false;
+		if (entries[i] & 1) return false;
 	return true;
 }
 
@@ -450,8 +435,7 @@ static bool is_table_empty (void* table_vaddr) {
  */
 static void free_all_vpages_in_range (vaddr_t first, vaddr_t last) {
 	pml4t_entry_t* pml4t_entry = &pml4_base_ptr[first.pml4_index];
-	if (!pml4t_entry->present)
-		return;
+	if (!pml4t_entry->present) return;
 
 	vaddr_t current = first;
 
@@ -495,8 +479,7 @@ static void free_all_vpages_in_range (vaddr_t first, vaddr_t last) {
 			}
 		}
 
-		if (!is_vaddr_t_lt (&current, &last))
-			break;
+		if (!is_vaddr_t_lt (&current, &last)) break;
 
 		current.pt_index++;
 		if (current.pt_index >= 512) {
@@ -516,8 +499,7 @@ static void free_all_vpages_in_range (vaddr_t first, vaddr_t last) {
  * @param count number of consecutive pages to free
  */
 void free_vpages (void* ptr, size_t count) {
-	if (ptr == NULL || count == 0)
-		return;
+	if (ptr == NULL || count == 0) return;
 
 	vaddr_t vaddr = get_vaddr_t_from_ptr (ptr);
 	if (vaddr.pml4_index != 1) {
@@ -526,8 +508,7 @@ void free_vpages (void* ptr, size_t count) {
 	}
 
 	void* phys_base = get_paddr (ptr);
-	if (phys_base == NULL)
-		return;
+	if (phys_base == NULL) return;
 
 	free_ppages (phys_base, count);
 
@@ -576,20 +557,17 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
  */
 void walk_pagetable () {
 	pml4t_entry_t* pml4t_entry = &pml4_base_ptr[1];
-	if (!pml4t_entry->present)
-		return;
+	if (!pml4t_entry->present) return;
 
 	pdpt_entry_t* pdpt_base_ptr =
 		(pdpt_entry_t*)get_vaddr_from_frame (pml4t_entry->pdpt_base_address);
 	pdpt_entry_t* pdpt_entry = &pdpt_base_ptr[0];
-	if (!pdpt_entry->present)
-		return;
+	if (!pdpt_entry->present) return;
 
 	pd_entry_t* pd_base_ptr = (pd_entry_t*)get_vaddr_from_frame (pdpt_entry->pd_base_address);
 	for (int k = 0; k < 512; k++) {
 		pd_entry_t* pd_entry = &pd_base_ptr[k];
-		if (!pd_entry->present)
-			continue;
+		if (!pd_entry->present) continue;
 		printf ("PD %d: PT Base Address:   0x%lx\n", k, pd_entry->pt_base_address << 12);
 		pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_from_frame (pd_entry->pt_base_address);
 
@@ -601,8 +579,7 @@ void walk_pagetable () {
 		int range_start = -1;
 		for (int k = 0; k <= 512; k++) {
 			if (k < 512 && is_present_pt[k]) {
-				if (range_start == -1)
-					range_start = k;
+				if (range_start == -1) range_start = k;
 			} else if (range_start != -1) {
 				if (range_start == k - 1)
 					printf ("  Present PT: %d\n", range_start);
@@ -623,14 +600,12 @@ void* get_paddr (void* vaddr) {
 	vaddr_t virtual_addr = get_vaddr_t_from_ptr (vaddr);
 
 	pml4t_entry_t* pml4t_entry = &pml4_base_ptr[virtual_addr.pml4_index];
-	if (!pml4t_entry->present)
-		return NULL;
+	if (!pml4t_entry->present) return NULL;
 
 	pdpt_entry_t* pdpt_base_ptr =
 		(pdpt_entry_t*)get_vaddr_from_frame (pml4t_entry->pdpt_base_address);
 	pdpt_entry_t* pdpt_entry = &pdpt_base_ptr[virtual_addr.pdpt_index];
-	if (!pdpt_entry->present)
-		return NULL;
+	if (!pdpt_entry->present) return NULL;
 
 	if (pdpt_entry->page_size) {
 		uint64_t phys_addr = (pdpt_entry->pd_base_address << 12) |
@@ -641,8 +616,7 @@ void* get_paddr (void* vaddr) {
 
 	pd_entry_t* pd_base_ptr = (pd_entry_t*)get_vaddr_from_frame (pdpt_entry->pd_base_address);
 	pd_entry_t* pd_entry = &pd_base_ptr[virtual_addr.pd_index];
-	if (!pd_entry->present)
-		return NULL;
+	if (!pd_entry->present) return NULL;
 
 	if (pd_entry->page_size) {
 		uint64_t phys_addr = (pd_entry->pt_base_address << 12) |
@@ -652,8 +626,7 @@ void* get_paddr (void* vaddr) {
 
 	pt_entry_t* pt_base_ptr = (pt_entry_t*)get_vaddr_from_frame (pd_entry->pt_base_address);
 	pt_entry_t* pt_entry = &pt_base_ptr[virtual_addr.pt_index];
-	if (!pt_entry->present)
-		return NULL;
+	if (!pt_entry->present) return NULL;
 
 	uint64_t phys_addr = (pt_entry->frame_base_address << 12) | virtual_addr.offset;
 
@@ -679,8 +652,7 @@ int liballoc_unlock (void) {
 void* liballoc_alloc (size_t count) { return alloc_vpages (count, false); }
 
 int liballoc_free (void* ptr, size_t count) {
-	if (is_locked)
-		return -7;
+	if (is_locked) return -7;
 
 	free_vpages (ptr, count);
 	return 0;

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -603,15 +603,12 @@ void walk_pagetable () {
 			if (k < 512 && is_present_pt[k]) {
 				if (range_start == -1)
 					range_start = k;
-			} else {
-				if (range_start != -1) {
-					if (range_start == k - 1) {
-						printf ("  Present PT: %d\n", range_start);
-					} else {
-						printf ("  Present PTs: %d-%d\n", range_start, k - 1);
-					}
-					range_start = -1;
-				}
+			} else if (range_start != -1) {
+				if (range_start == k - 1)
+					printf ("  Present PT: %d\n", range_start);
+				else
+					printf ("  Present PTs: %d-%d\n", range_start, k - 1);
+				range_start = -1;
 			}
 		}
 	}

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -16,11 +16,14 @@ memmap_bitmap bitmap;
 
 struct limine_memmap_response* memmap_response_ptr;
 
+// Handler definition for internal use only
+void page_fault_handler (registers_t* registers);
+
 /*!
  * Reads the value of the CR3 register, which contains the physical address of the PML4 table.
  * @return The value of the CR3 register.
  */
-uint64_t read_cr3 (void) {
+static uint64_t read_cr3 (void) {
 	uint64_t cr3;
 	__asm__ volatile ("mov %%cr3, %0" : "=r"(cr3));
 	return cr3;
@@ -94,7 +97,7 @@ static inline void bitmap_clear_bit (uint64_t page_idx) {
  * @param count number of consecutive frames to allocate
  * @return base physical address of allocated frames
  */
-paddr_t alloc_ppages (uint64_t count) {
+static paddr_t alloc_ppages (uint64_t count) {
 	if (count == 0) return NULL;
 	if (bitmap.pages_used + count > bitmap.pages_maxlen) return NULL;
 
@@ -127,14 +130,14 @@ paddr_t alloc_ppages (uint64_t count) {
  * Allocate a single physical frame
  * @return base physical address of allocated frame
  */
-paddr_t alloc_ppage (void) { return alloc_ppages (1); }
+static paddr_t alloc_ppage (void) { return alloc_ppages (1); }
 
 /*!
  * Free multiple consecutive physical frames
  * @param paddr base physical address of frames to free
  * @param count number of frames to free
  */
-void free_ppages (void* paddr, uint64_t count) {
+static void free_ppages (void* paddr, uint64_t count) {
 	uint64_t start_idx = (uint64_t)paddr / PAGE_SIZE;
 
 	for (uint64_t i = 0; i < count; i++) {
@@ -169,7 +172,7 @@ void free_ppages (void* paddr, uint64_t count) {
  * Free a single physical frame
  * @param paddr base physical address of frame to free
  */
-void free_ppage (void* paddr) { free_ppages (paddr, 1); }
+static void free_ppage (void* paddr) { free_ppages (paddr, 1); }
 
 static void init_physical_bitmap (struct limine_memmap_response* memmap_response) {
 	uint64_t addr_limit = 0;

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -551,7 +551,7 @@ void free_vpage (void* ptr) { free_vpages (ptr, 1); }
  * Sets the base pointer for the PML4 table and stores the HHDM offset.
  * @param p_hhdm_offset The higher half direct mapping offset.
  */
-void __init_memmgt__ (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_response) {
+void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_response) {
 	idt_register_handler (0xE, (irq_handler_t)page_fault_handler);
 	memmap_response_ptr = memmap_response;
 

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -8,7 +8,7 @@
 #define PAGE_SIZE 4096ull
 
 pml4t_entry_t* pml4_base_ptr = NULL;
-uint64_t hhdm_offset = 0;
+uint64_t	   hhdm_offset = 0;
 
 bool is_locked = false;
 
@@ -33,7 +33,7 @@ uint64_t read_cr3 (void) {
  */
 vaddr_t get_vaddr_t_from_ptr (void* ptr) {
 	uint64_t ptr_64t = (uint64_t)ptr;
-	vaddr_t ret_vaddr;
+	vaddr_t	 ret_vaddr;
 
 	ret_vaddr.offset = ptr_64t & 0xFFF;
 	ret_vaddr.pt_index = (ptr_64t >> 12) & 0x1FF;
@@ -139,7 +139,7 @@ void free_ppages (void* paddr, uint64_t count) {
 
 	for (uint64_t i = 0; i < count; i++) {
 		uint64_t current_paddr = (uint64_t)paddr + (i * PAGE_SIZE);
-		bool is_valid = false;
+		bool	 is_valid = false;
 
 		if (memmap_response_ptr != NULL) {
 			for (uint64_t j = 0; j < memmap_response_ptr->entry_count; j++) {
@@ -269,7 +269,7 @@ static bool is_vaddr_t_lt (vaddr_t* a, vaddr_t* b) {
  * @param base_addr base address of physical memory of corresponding size
  */
 static void alloc_all_vpages_in_range (vaddr_t first, vaddr_t last, paddr_t base_addr, bool user) {
-	uint64_t phys_base_track = (uint64_t)base_addr;
+	uint64_t	   phys_base_track = (uint64_t)base_addr;
 	pml4t_entry_t* pml4t_entry = &pml4_base_ptr[first.pml4_index];
 
 	vaddr_t current = first;
@@ -334,7 +334,7 @@ void* alloc_vpages (size_t req_count, bool user) {
 	pml4t_entry_t* pml4t_entry = &pml4_base_ptr[1];
 	if (!pml4t_entry->present) return NULL;
 
-	size_t count_so_far = 0;
+	size_t	 count_so_far = 0;
 	uint64_t start_page_idx = 0;
 
 	for (uint64_t i = 0; i < 512ull * 512ull * 512ull;) {

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -20,7 +20,7 @@ struct limine_memmap_response* memmap_response_ptr;
  * Reads the value of the CR3 register, which contains the physical address of the PML4 table.
  * @return The value of the CR3 register.
  */
-uint64_t read_cr3 () {
+uint64_t read_cr3 (void) {
 	uint64_t cr3;
 	__asm__ volatile ("mov %%cr3, %0" : "=r"(cr3));
 	return cr3;
@@ -131,7 +131,7 @@ paddr_t alloc_ppages (uint64_t count) {
  * Allocate a single physical frame
  * @return base physical address of allocated frame
  */
-paddr_t alloc_ppage () { return alloc_ppages (1); }
+paddr_t alloc_ppage (void) { return alloc_ppages (1); }
 
 /*!
  * Free multiple consecutive physical frames
@@ -666,12 +666,12 @@ LIBALLOC FUNCTION IMPLEMENTATIONS
 
 */
 
-int liballoc_lock () {
+int liballoc_lock (void) {
 	is_locked = true;
 	return 0;
 }
 
-int liballoc_unlock () {
+int liballoc_unlock (void) {
 	is_locked = false;
 	return 0;
 }

--- a/kernel/src/kernel/serial.c
+++ b/kernel/src/kernel/serial.c
@@ -6,7 +6,7 @@
  * Textbook implementation, see: https://wiki.osdev.org/Serial_Ports
  * @return 0 if initialised, 1 if port faulty
  */
-int __init_serial__ (void) {
+int init_serial (void) {
 	outb (SERIAL_COM_1 + 1, 0x00); // Disable all interrupts
 	outb (SERIAL_COM_1 + 3, 0x80); // Enable DLAB (set baud rate divisor)
 	outb (SERIAL_COM_1 + 0, 0x03); // Set divisor to 3 (lo byte) 38400 baud

--- a/kernel/src/kernel/serial.c
+++ b/kernel/src/kernel/serial.c
@@ -19,9 +19,8 @@ int init_serial (void) {
 		  0xAE); // Test serial chip (send byte 0xAE and check if serial returns same byte)
 
 	// Check if serial is faulty (i.e: not same byte as sent)
-	if (inb (SERIAL_COM_1 + 0) != 0xAE) {
+	if (inb (SERIAL_COM_1 + 0) != 0xAE)
 		return 1;
-	}
 
 	// If serial is not faulty set it in normal operation mode
 	// (not-loopback with IRQs enabled and OUT#1 and OUT#2 bits enabled)

--- a/kernel/src/kernel/serial.c
+++ b/kernel/src/kernel/serial.c
@@ -19,8 +19,7 @@ int init_serial (void) {
 		  0xAE); // Test serial chip (send byte 0xAE and check if serial returns same byte)
 
 	// Check if serial is faulty (i.e: not same byte as sent)
-	if (inb (SERIAL_COM_1 + 0) != 0xAE)
-		return 1;
+	if (inb (SERIAL_COM_1 + 0) != 0xAE) return 1;
 
 	// If serial is not faulty set it in normal operation mode
 	// (not-loopback with IRQs enabled and OUT#1 and OUT#2 bits enabled)

--- a/kernel/src/kernel/syscall.c
+++ b/kernel/src/kernel/syscall.c
@@ -3,7 +3,7 @@
 
 void syscall_handler (registers_t* registers) { uint8_t syscall_number = registers->rax; }
 
-void __init_syscalls__ (void) {
+void init_syscalls (void) {
 	idt_register_handler (0x80, syscall_handler);
 	idt_set_flags (0x80, 0x0E, 3, 0);
 }

--- a/kernel/src/liballoc/liballoc.c
+++ b/kernel/src/liballoc/liballoc.c
@@ -214,9 +214,8 @@ void* PREFIX (malloc) (size_t req_size) {
 	unsigned long size = req_size;
 
 	// For alignment, we adjust size so there's enough space to align.
-	if (ALIGNMENT > 1) {
+	if (ALIGNMENT > 1)
 		size += ALIGNMENT + ALIGN_INFO;
-	}
 	// So, ideally, we really want an alignment of 0 or 1 in order
 	// to save space.
 
@@ -608,14 +607,12 @@ void PREFIX (free) (void* ptr) {
 		l_allocated -= maj->size;
 
 		liballoc_free (maj, maj->pages);
-	} else {
-		if (l_bestBet != NULL) {
-			int bestSize = l_bestBet->size - l_bestBet->usage;
-			int majSize = maj->size - maj->usage;
+	} else if (l_bestBet != NULL) {
+		int bestSize = l_bestBet->size - l_bestBet->usage;
+		int majSize = maj->size - maj->usage;
 
-			if (majSize > bestSize)
-				l_bestBet = maj;
-		}
+		if (majSize > bestSize)
+			l_bestBet = maj;
 	}
 
 #ifdef DEBUG

--- a/kernel/src/liballoc/liballoc.c
+++ b/kernel/src/liballoc/liballoc.c
@@ -169,8 +169,7 @@ static struct liballoc_major* allocate_new_page (unsigned int size) {
 	// No, add the buffer.
 
 	// Make sure it's >= the minimum size.
-	if (st < l_pageCount)
-		st = l_pageCount;
+	if (st < l_pageCount) st = l_pageCount;
 
 	maj = (struct liballoc_major*)liballoc_alloc (st);
 
@@ -214,8 +213,7 @@ void* PREFIX (malloc) (size_t req_size) {
 	unsigned long size = req_size;
 
 	// For alignment, we adjust size so there's enough space to align.
-	if (ALIGNMENT > 1)
-		size += ALIGNMENT + ALIGN_INFO;
+	if (ALIGNMENT > 1) size += ALIGNMENT + ALIGN_INFO;
 	// So, ideally, we really want an alignment of 0 or 1 in order
 	// to save space.
 
@@ -311,8 +309,7 @@ void* PREFIX (malloc) (size_t req_size) {
 
 			// Create a new major block next to this one and...
 			maj->next = allocate_new_page (size); // next one will be okay.
-			if (maj->next == NULL)
-				break; // no more memory.
+			if (maj->next == NULL) break;		  // no more memory.
 			maj->next->prev = maj;
 			maj = maj->next;
 
@@ -492,8 +489,7 @@ void* PREFIX (malloc) (size_t req_size) {
 
 			// we've run out. we need more...
 			maj->next = allocate_new_page (size); // next one guaranteed to be okay
-			if (maj->next == NULL)
-				break; //  uh oh,  no more memory.....
+			if (maj->next == NULL) break;		  //  uh oh,  no more memory.....
 			maj->next->prev = maj;
 		}
 
@@ -582,13 +578,10 @@ void PREFIX (free) (void* ptr) {
 	maj->usage -= (min->size + sizeof (struct liballoc_minor));
 	min->magic = LIBALLOC_DEAD; // No mojo.
 
-	if (min->next != NULL)
-		min->next->prev = min->prev;
-	if (min->prev != NULL)
-		min->prev->next = min->next;
+	if (min->next != NULL) min->next->prev = min->prev;
+	if (min->prev != NULL) min->prev->next = min->next;
 
-	if (min->prev == NULL)
-		maj->first = min->next;
+	if (min->prev == NULL) maj->first = min->next;
 	// Might empty the block. This was the first
 	// minor.
 
@@ -596,14 +589,10 @@ void PREFIX (free) (void* ptr) {
 
 	if (maj->first == NULL) // Block completely unused.
 	{
-		if (l_memRoot == maj)
-			l_memRoot = maj->next;
-		if (l_bestBet == maj)
-			l_bestBet = NULL;
-		if (maj->prev != NULL)
-			maj->prev->next = maj->next;
-		if (maj->next != NULL)
-			maj->next->prev = maj->prev;
+		if (l_memRoot == maj) l_memRoot = maj->next;
+		if (l_bestBet == maj) l_bestBet = NULL;
+		if (maj->prev != NULL) maj->prev->next = maj->next;
+		if (maj->next != NULL) maj->next->prev = maj->prev;
 		l_allocated -= maj->size;
 
 		liballoc_free (maj, maj->pages);
@@ -611,8 +600,7 @@ void PREFIX (free) (void* ptr) {
 		int bestSize = l_bestBet->size - l_bestBet->usage;
 		int majSize = maj->size - maj->usage;
 
-		if (majSize > bestSize)
-			l_bestBet = maj;
+		if (majSize > bestSize) l_bestBet = maj;
 	}
 
 #ifdef DEBUG
@@ -648,8 +636,7 @@ void* PREFIX (realloc) (void* p, size_t size) {
 	}
 
 	// In the case of a NULL pointer, return a simple malloc.
-	if (p == NULL)
-		return PREFIX (malloc) (size);
+	if (p == NULL) return PREFIX (malloc) (size);
 
 	// Unalign the pointer if required.
 	ptr = p;

--- a/kernel/src/liballoc/liballoc.c
+++ b/kernel/src/liballoc/liballoc.c
@@ -56,9 +56,9 @@
 struct liballoc_major {
 	struct liballoc_major* prev;  ///< Linked list information.
 	struct liballoc_major* next;  ///< Linked list information.
-	unsigned int pages;			  ///< The number of pages in the block.
-	unsigned int size;			  ///< The number of pages in the block.
-	unsigned int usage;			  ///< The number of bytes used in the block.
+	unsigned int		   pages; ///< The number of pages in the block.
+	unsigned int		   size;  ///< The number of pages in the block.
+	unsigned int		   usage; ///< The number of bytes used in the block.
 	struct liballoc_minor* first; ///< A pointer to the first allocated memory in the block.
 };
 
@@ -67,12 +67,12 @@ struct liballoc_major {
  * malloc, calloc, realloc call.
  */
 struct liballoc_minor {
-	struct liballoc_minor* prev;  ///< Linked list information.
-	struct liballoc_minor* next;  ///< Linked list information.
-	struct liballoc_major* block; ///< The owning block. A pointer to the major structure.
-	unsigned int magic;			  ///< A magic number to idenfity correctness.
-	unsigned int size;			  ///< The size of the memory allocated. Could be 1 byte or more.
-	unsigned int req_size;		  ///< The size of memory requested.
+	struct liballoc_minor* prev;	 ///< Linked list information.
+	struct liballoc_minor* next;	 ///< Linked list information.
+	struct liballoc_major* block;	 ///< The owning block. A pointer to the major structure.
+	unsigned int		   magic;	 ///< A magic number to idenfity correctness.
+	unsigned int		   size;	 ///< The size of the memory allocated. Could be 1 byte or more.
+	unsigned int		   req_size; ///< The size of memory requested.
 };
 
 static struct liballoc_major* l_memRoot = NULL; ///< The root memory block acquired from the system.
@@ -98,8 +98,8 @@ static void* liballoc_memset (void* s, int c, size_t n) {
 	return s;
 }
 static void* liballoc_memcpy (void* s1, const void* s2, size_t n) {
-	char* cdest;
-	char* csrc;
+	char*		  cdest;
+	char*		  csrc;
 	unsigned int* ldest = (unsigned int*)s1;
 	unsigned int* lsrc = (unsigned int*)s2;
 
@@ -154,7 +154,7 @@ static void liballoc_dump () {
 // ***************************************************************
 
 static struct liballoc_major* allocate_new_page (unsigned int size) {
-	unsigned int st;
+	unsigned int		   st;
 	struct liballoc_major* maj;
 
 	// This is how much space is required.
@@ -203,14 +203,14 @@ static struct liballoc_major* allocate_new_page (unsigned int size) {
 }
 
 void* PREFIX (malloc) (size_t req_size) {
-	int startedBet = 0;
-	unsigned long long bestSize = 0;
-	void* p = NULL;
-	uintptr_t diff;
+	int					   startedBet = 0;
+	unsigned long long	   bestSize = 0;
+	void*				   p = NULL;
+	uintptr_t			   diff;
 	struct liballoc_major* maj;
 	struct liballoc_minor* min;
 	struct liballoc_minor* new_min;
-	unsigned long size = req_size;
+	unsigned long		   size = req_size;
 
 	// For alignment, we adjust size so there's enough space to align.
 	if (ALIGNMENT > 1) size += ALIGNMENT + ALIGN_INFO;
@@ -612,7 +612,7 @@ void PREFIX (free) (void* ptr) {
 }
 
 void* PREFIX (calloc) (size_t nobj, size_t size) {
-	int real_size;
+	int	  real_size;
 	void* p;
 
 	real_size = nobj * size;
@@ -625,9 +625,9 @@ void* PREFIX (calloc) (size_t nobj, size_t size) {
 }
 
 void* PREFIX (realloc) (void* p, size_t size) {
-	void* ptr;
+	void*				   ptr;
 	struct liballoc_minor* min;
-	unsigned int real_size;
+	unsigned int		   real_size;
 
 	// Honour the case of size == 0 => free old and return NULL
 	if (size == 0) {

--- a/kernel/src/liballoc/liballoc.c
+++ b/kernel/src/liballoc/liballoc.c
@@ -40,7 +40,7 @@
 	}
 
 #define LIBALLOC_MAGIC 0xc001c0de
-#define LIBALLOC_DEAD 0xdeaddead
+#define LIBALLOC_DEAD  0xdeaddead
 
 #if defined DEBUG || defined INFO
 #include <stdio.h>

--- a/kernel/src/memory.c
+++ b/kernel/src/memory.c
@@ -9,7 +9,7 @@ Copy memory chunk of size n.
 @param  n width of data
 */
 void* memcpy (void* dest, const void* src, size_t n) {
-	uint8_t* pdest = (uint8_t*)dest;
+	uint8_t*	   pdest = (uint8_t*)dest;
 	const uint8_t* psrc = (const uint8_t*)src;
 
 	for (size_t i = 0; i < n; i++)
@@ -42,7 +42,7 @@ Move memory chunk.
 @param  n width of data
 */
 void* memmove (void* dest, const void* src, size_t n) {
-	uint8_t* pdest = (uint8_t*)dest;
+	uint8_t*	   pdest = (uint8_t*)dest;
 	const uint8_t* psrc = (const uint8_t*)src;
 
 	if (src > dest)

--- a/kernel/src/memory.c
+++ b/kernel/src/memory.c
@@ -12,9 +12,8 @@ void* memcpy (void* dest, const void* src, size_t n) {
 	uint8_t* pdest = (uint8_t*)dest;
 	const uint8_t* psrc = (const uint8_t*)src;
 
-	for (size_t i = 0; i < n; i++) {
+	for (size_t i = 0; i < n; i++)
 		pdest[i] = psrc[i];
-	}
 
 	return dest;
 }
@@ -29,9 +28,8 @@ Set memory chunk of size n to be value c.
 void* memset (void* s, int c, size_t n) {
 	uint8_t* p = (uint8_t*)s;
 
-	for (size_t i = 0; i < n; i++) {
+	for (size_t i = 0; i < n; i++)
 		p[i] = (uint8_t)c;
-	}
 
 	return s;
 }
@@ -47,15 +45,12 @@ void* memmove (void* dest, const void* src, size_t n) {
 	uint8_t* pdest = (uint8_t*)dest;
 	const uint8_t* psrc = (const uint8_t*)src;
 
-	if (src > dest) {
-		for (size_t i = 0; i < n; i++) {
+	if (src > dest)
+		for (size_t i = 0; i < n; i++)
 			pdest[i] = psrc[i];
-		}
-	} else if (src < dest) {
-		for (size_t i = n; i > 0; i--) {
+	else if (src < dest)
+		for (size_t i = n; i > 0; i--)
 			pdest[i - 1] = psrc[i - 1];
-		}
-	}
 
 	return dest;
 }
@@ -72,11 +67,9 @@ int memcmp (const void* s1, const void* s2, size_t n) {
 	const uint8_t* p1 = (const uint8_t*)s1;
 	const uint8_t* p2 = (const uint8_t*)s2;
 
-	for (size_t i = 0; i < n; i++) {
-		if (p1[i] != p2[i]) {
+	for (size_t i = 0; i < n; i++)
+		if (p1[i] != p2[i])
 			return p1[i] < p2[i] ? -1 : 1;
-		}
-	}
 
 	return 0;
 }

--- a/kernel/src/memory.c
+++ b/kernel/src/memory.c
@@ -68,8 +68,7 @@ int memcmp (const void* s1, const void* s2, size_t n) {
 	const uint8_t* p2 = (const uint8_t*)s2;
 
 	for (size_t i = 0; i < n; i++)
-		if (p1[i] != p2[i])
-			return p1[i] < p2[i] ? -1 : 1;
+		if (p1[i] != p2[i]) return p1[i] < p2[i] ? -1 : 1;
 
 	return 0;
 }

--- a/kernel/src/stdio.c
+++ b/kernel/src/stdio.c
@@ -10,7 +10,7 @@ Handle the different cases of %-- in printf
 @param	args	pointer to the arguments printf received
 @param	ul	whether the format prints an unsigned/long character
 */
-void fmtprintf (const char* format, size_t* i, va_list* args, bool ul) {
+static void fmtprintf (const char* format, size_t* i, va_list* args, bool ul) {
 	switch (format[*i]) {
 	case 's': {
 		const char* str = va_arg (*args, const char*);

--- a/kernel/src/string.c
+++ b/kernel/src/string.c
@@ -38,7 +38,7 @@ Convert integer to representative string with base b.
 @param  b base
 */
 void itos (int32_t i, char* buf, uint32_t b) {
-	int ctr = 0;
+	int	 ctr = 0;
 	bool negative = false;
 	if (i < 0) {
 		i = -i;
@@ -65,7 +65,7 @@ Convert long integer to representative string with base b.
 @param  b base
 */
 void ulitos (uint64_t i, char* buf, uint32_t b) {
-	int ctr = 0;
+	int	 ctr = 0;
 	bool negative = false;
 	do {
 		if (i % b < 10)
@@ -99,7 +99,7 @@ int strcmp (const char* a, const char* b) {
 char* strdup (const char* s) {
 	if (!s) return NULL;
 	size_t len = strlen (s);
-	char* dup = (char*)kmalloc (len + 1);
+	char*  dup = (char*)kmalloc (len + 1);
 	if (!dup) return NULL;
 	for (size_t i = 0; i <= len; i++)
 		dup[i] = s[i];

--- a/kernel/src/string.c
+++ b/kernel/src/string.c
@@ -51,10 +51,8 @@ void itos (int32_t i, char* buf, uint32_t b) {
 			buf[ctr++] = 'a' + i % b - 10;
 		i /= b;
 	} while (i);
-	if (ctr == 0)
-		buf[0] = '0';
-	if (negative)
-		buf[ctr++] = '-';
+	if (ctr == 0) buf[0] = '0';
+	if (negative) buf[ctr++] = '-';
 	buf[ctr + 1] = 0;
 	reverse (buf);
 }
@@ -76,10 +74,8 @@ void ulitos (uint64_t i, char* buf, uint32_t b) {
 			buf[ctr++] = 'a' + i % b - 10;
 		i /= b;
 	} while (i);
-	if (ctr == 0)
-		buf[0] = '0';
-	if (negative)
-		buf[ctr++] = '-';
+	if (ctr == 0) buf[0] = '0';
+	if (negative) buf[ctr++] = '-';
 	buf[ctr++] = 0;
 	reverse (buf);
 }
@@ -92,8 +88,7 @@ void ulitos (uint64_t i, char* buf, uint32_t b) {
  */
 int strcmp (const char* a, const char* b) {
 	for (int i = 0; a[i] != 0 && b[i] != 0; i++)
-		if (a[i] != b[i])
-			return 1;
+		if (a[i] != b[i]) return 1;
 	return 0;
 }
 
@@ -102,12 +97,10 @@ int strcmp (const char* a, const char* b) {
  * Returns a newly allocated copy or NULL on failure.
  */
 char* strdup (const char* s) {
-	if (!s)
-		return NULL;
+	if (!s) return NULL;
 	size_t len = strlen (s);
 	char* dup = (char*)kmalloc (len + 1);
-	if (!dup)
-		return NULL;
+	if (!dup) return NULL;
 	for (size_t i = 0; i <= len; i++)
 		dup[i] = s[i];
 	return dup;

--- a/user/hello/Makefile
+++ b/user/hello/Makefile
@@ -35,6 +35,8 @@ override CFLAGS += \
 	-Wall \
 	-Wextra \
 	-Wstrict-prototypes \
+	-Wmissing-prototypes \
+	-Wmissing-declarations \
 	-std=gnu11 \
 	-ffreestanding \
 	-fno-stack-protector \

--- a/user/hello/Makefile
+++ b/user/hello/Makefile
@@ -34,6 +34,7 @@ $(eval $(call DEFAULT_VAR,LDFLAGS,$(DEFAULT_LDFLAGS)))
 override CFLAGS += \
 	-Wall \
 	-Wextra \
+	-Wstrict-prototypes \
 	-std=gnu11 \
 	-ffreestanding \
 	-fno-stack-protector \

--- a/user/hello/hello.c
+++ b/user/hello/hello.c
@@ -14,7 +14,6 @@ void _start (void) {
 	syscall3 (4, 1, (long)msg, 13);
 	syscall3 (1, 0, 0, 0);
 
-	while (1) {
+	while (1)
 		__asm__ volatile ("pause");
-	}
 }

--- a/user/hello/hello.c
+++ b/user/hello/hello.c
@@ -1,4 +1,6 @@
 
+void _start (void);
+
 static inline long syscall3 (long num, long arg1, long arg2, long arg3) {
 	long ret;
 	__asm__ volatile ("int $0x80"


### PR DESCRIPTION
Add these clang format options:

```
RemoveBracesLLVM: true
AlignConsecutiveMacros: true
AllowShortIfStatementsOnASingleLine: WithoutElse
ReflowComments: true
SortIncludes: true
AlignConsecutiveDeclarations: true
```

Add these C flags (and deal with resulting warnings):

```
-Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations
```

Rename `__init_*__` functions to `init_*` (removing double underscore)