### PR TITLE
Make syscalls registerable

### DIFF
--- a/kernel/include/kernel/fs/vfs.h
+++ b/kernel/include/kernel/fs/vfs.h
@@ -53,11 +53,11 @@ int do_seek (struct file* f, size_t offset, int whence);
 int do_open (inode* file, struct file* dest_fd);
 int do_close (struct file* fd);
 
-int sys_read (int fd, void* buf, size_t size);
-int sys_seek (int fd, size_t offset, int whence);
-int sys_open (char* filename, int flags, int mode);
-int sys_close (int fd);
-int sys_mkdir (char* path, int mode);
+uint64_t sys_read (uint64_t fd, uint64_t buf, uint64_t size);
+uint64_t sys_seek (uint64_t fd, uint64_t offset, uint64_t whence);
+uint64_t sys_open (uint64_t filename_ptr, uint64_t flags, uint64_t mode);
+uint64_t sys_close (uint64_t fd, uint64_t arg2, uint64_t arg3);
+uint64_t sys_mkdir (uint64_t path, uint64_t mode, uint64_t arg3);
 
 inode* get_absolute_root (void);
 void   init_vfs (inode* absolute_root);

--- a/kernel/include/kernel/syscall.h
+++ b/kernel/include/kernel/syscall.h
@@ -13,6 +13,7 @@ typedef uint64_t (*syscall_handler_t) (uint64_t, uint64_t, uint64_t);
 registers_t* syscall_handler (registers_t* registers);
 void		 init_syscalls (void);
 
+void	 register_syscall (syscall_handler_t handler, int vector);
 uint64_t do_syscall (uint64_t syscall, uint64_t arg1, uint64_t arg2, uint64_t arg3);
 
 #endif

--- a/kernel/include/kernel/syscall.h
+++ b/kernel/include/kernel/syscall.h
@@ -4,7 +4,11 @@
 
 #include <kernel/idt.h>
 
+#define SYSCALL_COUNT 256
+
 #define SYSCALL_SYS_FORK 57
+
+typedef uint64_t (*syscall_handler_t) (uint64_t, uint64_t, uint64_t);
 
 registers_t* syscall_handler (registers_t* registers);
 void		 init_syscalls (void);

--- a/kernel/include/kernel/syscall.h
+++ b/kernel/include/kernel/syscall.h
@@ -6,14 +6,20 @@
 
 #define SYSCALL_COUNT 256
 
-#define SYSCALL_SYS_FORK 57
+#define SYSCALL_SYS_READ  3
+#define SYSCALL_SYS_WRITE 4
+#define SYSCALL_SYS_OPEN  5
+#define SYSCALL_SYS_CLOSE 6
+#define SYSCALL_SYS_LSEEK 19
+#define SYSCALL_SYS_MKDIR 39
+#define SYSCALL_SYS_FORK  57
 
 typedef uint64_t (*syscall_handler_t) (uint64_t, uint64_t, uint64_t);
 
 registers_t* syscall_handler (registers_t* registers);
 void		 init_syscalls (void);
 
-void	 register_syscall (syscall_handler_t handler, int vector);
+void	 register_syscall (int vector, syscall_handler_t handler);
 uint64_t do_syscall (uint64_t syscall, uint64_t arg1, uint64_t arg2, uint64_t arg3);
 
 #endif

--- a/kernel/src/kernel/elf.c
+++ b/kernel/src/kernel/elf.c
@@ -2,6 +2,7 @@
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/memmgt.h>
+#include <kernel/syscall.h>
 #include <liballoc/liballoc.h>
 #include <memory.h>
 #include <stdbool.h>
@@ -33,13 +34,15 @@ bool verify_elf_loadable (elf64_header_t* elf) {
 
 int load_elf (const char* filepath, process* target_process, uintptr_t* entry_point_r) {
 	// TODO: open file as readonly once flags implemented
-	int fd = sys_open (filepath, 0, 0);
+	int64_t fd = (int64_t)do_syscall (SYSCALL_SYS_OPEN, (uint64_t)filepath, 0ull, 0ull);
 	if (fd < 0) return fd;
 
 	elf64_header_t elf_header;
-	int			   bytes_read = sys_read (fd, &elf_header, sizeof (elf64_header_t));
+
+	int64_t bytes_read = (int64_t)do_syscall (SYSCALL_SYS_READ, (uint64_t)fd, (uint64_t)&elf_header,
+								 (uint64_t)sizeof (elf64_header_t));
 	if (bytes_read != sizeof (elf64_header_t) || !verify_elf_loadable (&elf_header)) {
-		sys_close (fd);
+		do_syscall (SYSCALL_SYS_CLOSE, fd, 0, 0);
 		return -ENOEXEC;
 	}
 
@@ -49,8 +52,8 @@ int load_elf (const char* filepath, process* target_process, uintptr_t* entry_po
 	size_t			 ph_size = elf_header.elf_phnum * elf_header.elf_phentsize;
 	elf64_pheader_t* program_headers = kmalloc (ph_size);
 
-	sys_seek (fd, elf_header.elf_phoff, SEEK_SET);
-	sys_read (fd, program_headers, ph_size);
+	do_syscall (SYSCALL_SYS_LSEEK, fd, elf_header.elf_phoff, SEEK_SET);
+	do_syscall (SYSCALL_SYS_READ, fd, (uint64_t)program_headers, ph_size);
 
 	for (int i = 0; i < elf_header.elf_phnum; i++) {
 		elf64_pheader_t* ph = &program_headers[i];
@@ -65,15 +68,15 @@ int load_elf (const char* filepath, process* target_process, uintptr_t* entry_po
 
 		alloc_by_cr3 (target_process->p_cr3, (uintptr_t)start, num_pages, is_writable);
 
-		sys_seek (fd, ph->p_offset, SEEK_SET);
-		sys_read (fd, (void*)ph->p_vaddr, ph->p_filesz);
+		do_syscall (SYSCALL_SYS_LSEEK, fd, ph->p_offset, SEEK_SET);
+		do_syscall (SYSCALL_SYS_READ, fd, ph->p_vaddr, ph->p_filesz);
 
 		if (ph->p_memsz > ph->p_filesz)
 			memset ((void*)(ph->p_vaddr + ph->p_filesz), 0, ph->p_memsz - ph->p_filesz);
 	}
 
 	kfree (program_headers);
-	sys_close (fd);
+	do_syscall (SYSCALL_SYS_CLOSE, fd, 0, 0);
 
 	*entry_point_r = elf_header.elf_entry;
 	return 0;

--- a/kernel/src/kernel/fs/vfs.c
+++ b/kernel/src/kernel/fs/vfs.c
@@ -2,6 +2,7 @@
 #include <kernel/fs/vfs.h>
 #include <kernel/process.h>
 #include <kernel/serial.h>
+#include <kernel/syscall.h>
 #include <liballoc/liballoc.h>
 #include <memory.h>
 #include <stdbool.h>
@@ -92,17 +93,19 @@ int do_mkdir (char* dirname, inode** result, inode* parent) {
 
 /*!
  * Create a directory at the given path.
- * @param us_path absolute path for the new directory
+ * @param path absolute path for the new directory
  * @param mode (unused) mode for the new directory
  * @return 0 if successful, error otherwise
  */
-int sys_mkdir (char* path, int mode) {
+uint64_t sys_mkdir (uint64_t path, uint64_t mode, uint64_t arg3) {
+	(void)arg3;
+
 	process* current = get_current_process ();
 	if (!current) return -EINVARG;
 
 	inode* parent;
 	char*  name;
-	int	   err = vfs_resolve_parent (path, current->p_root, &parent, &name);
+	int	   err = vfs_resolve_parent ((const char*)path, current->p_root, &parent, &name);
 	if (err) return err;
 
 	inode* result;
@@ -287,12 +290,13 @@ int do_close (struct file* fd) {
 
 /*!
  * Resolve a filename and allocate a file descriptor, allowing for execution of read
- * @param filename absolute path to the file
+ * @param filename_ptr absolute path to the file
  * @param flags (unused) flags for the file
  * @param mode (unused) mode in which to open the file
  * @return fd if successful, else error
  */
-int sys_open (char* filename, int flags, int mode) {
+uint64_t sys_open (uint64_t filename_ptr, uint64_t flags, uint64_t mode) {
+	char* filename = (char*)filename_ptr;
 	if (!filename) return -EINVARG;
 
 	process* current = get_current_process ();
@@ -328,16 +332,24 @@ cleanup:
  * @param size desired read size
  * @return actual bytes read if successful, error (<0) otherwise
  */
-int sys_read (int fd, void* buf, size_t size) {
+uint64_t sys_read (uint64_t fd, uint64_t buf, uint64_t size) {
 	process* current = get_current_process ();
-	if (fd < 0 || fd >= MAX_FDS || !current->p_fds[fd]) return -EINVARG;
-	return do_read (current->p_fds[fd], buf, size);
+	if (fd >= MAX_FDS || !current || !current->p_fds[fd]) return -EINVARG;
+	return do_read (current->p_fds[fd], (void*)buf, (size_t)size);
 }
 
-int sys_seek (int fd, size_t offset, int whence) {
+/*!
+ * Seek to an offset in an open file. Behavior depends on whence: SEEK_SET -> seek exactly offset,
+ * SEEK_CUR -> seek current offset plus given offset, SEEK_END -> seek end of file plus given offset
+ * @param fd file descriptor
+ * @param offset offset value
+ * @param whence SEEK_SET, SEEK_CUR or SEEK_END
+ * @return 0 if successful, else error
+ */
+uint64_t sys_seek (uint64_t fd, uint64_t offset, uint64_t whence) {
 	process* current = get_current_process ();
-	if (fd < 0 || fd >= MAX_FDS || !current->p_fds[fd]) return -EINVARG;
-	return do_seek (current->p_fds[fd], offset, whence);
+	if (fd >= MAX_FDS || !current || !current->p_fds[fd]) return -EINVARG;
+	return do_seek (current->p_fds[fd], (size_t)offset, (int)whence);
 }
 
 /*!
@@ -346,16 +358,27 @@ int sys_seek (int fd, size_t offset, int whence) {
  * @param fd file descriptor
  * @return 0 if successful, else error
  */
-int sys_close (int fd) {
+uint64_t sys_close (uint64_t fd, uint64_t arg2, uint64_t arg3) {
+	(void)arg2, (void)arg3; // unused args
+
 	process* current = get_current_process ();
-	if (fd < 0 || fd >= MAX_FDS || !current || !current->p_fds[fd]) return -EINVARG;
+	if (fd >= MAX_FDS || !current || !current->p_fds[fd]) return -EINVARG;
 
 	struct file* f = current->p_fds[fd];
 	current->p_fds[fd] = NULL;
 
-	return do_close (f);
+	return (uint64_t)do_close (f);
 }
 
 inode* get_absolute_root (void) { return vfs_absolute_root; }
 
-void init_vfs (inode* absolute_root) { vfs_absolute_root = absolute_root; }
+void init_vfs (inode* absolute_root) {
+	vfs_absolute_root = absolute_root;
+
+	register_syscall (SYSCALL_SYS_READ, sys_read);
+	register_syscall (SYSCALL_SYS_OPEN, sys_open);
+	register_syscall (SYSCALL_SYS_CLOSE, sys_close);
+	register_syscall (SYSCALL_SYS_LSEEK, sys_seek);
+	register_syscall (SYSCALL_SYS_MKDIR, sys_mkdir);
+	register_syscall (SYSCALL_SYS_OPEN, sys_open);
+}

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -3,9 +3,9 @@
 #include <kernel/memmgt.h>
 #include <kernel/process.h>
 #include <kernel/stack.h>
+#include <kernel/syscall.h>
 #include <liballoc/liballoc.h>
 #include <memory.h>
-#include <kernel/syscall.h>
 
 process_queue ready_queue;
 uint64_t	  next_free_pid;
@@ -155,5 +155,5 @@ void init_process (void) {
 	ready_queue.head = ready_queue.tail = NULL;
 	next_free_pid = 2ll;
 
-	register_syscall(sys_fork, SYSCALL_SYS_FORK);
+	register_syscall (SYSCALL_SYS_FORK, sys_fork);
 }

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -5,6 +5,7 @@
 #include <kernel/stack.h>
 #include <liballoc/liballoc.h>
 #include <memory.h>
+#include <kernel/syscall.h>
 
 process_queue ready_queue;
 uint64_t	  next_free_pid;
@@ -141,10 +142,18 @@ int process_fork (process* source_process, process** dest_ptr) {
 
 	source_process->p_registers_ptr->rax = new_process->p_id;
 	*dest_ptr = new_process;
-	return 0;
+	return new_process->p_id;
+}
+
+uint64_t sys_fork (uint64_t arg1, uint64_t arg2, uint64_t arg3) {
+	(void)arg1, (void)arg2, (void)arg3; // fork does not use any args
+	process* child = NULL;
+	return process_fork (get_current_process (), &child);
 }
 
 void init_process (void) {
 	ready_queue.head = ready_queue.tail = NULL;
 	next_free_pid = 2ll;
+
+	register_syscall(sys_fork, SYSCALL_SYS_FORK);
 }

--- a/kernel/src/kernel/syscall.c
+++ b/kernel/src/kernel/syscall.c
@@ -1,9 +1,10 @@
-#include <kernel/process.h>
-#include <kernel/syscall.h>
-#include <kernel/serial.h>
 #include <kernel/error.h>
+#include <kernel/process.h>
+#include <kernel/serial.h>
+#include <kernel/syscall.h>
+#include <memory.h>
 
-syscall_handler_t syscall_handlers [SYSCALL_COUNT];
+syscall_handler_t syscall_handlers[SYSCALL_COUNT];
 
 registers_t* syscall_handler (registers_t* registers) {
 	uint64_t vector = registers->rax;
@@ -14,7 +15,7 @@ registers_t* syscall_handler (registers_t* registers) {
 	if (syscall_handlers[vector]) {
 		registers->rax = syscall_handlers[vector](registers->rdi, registers->rsi, registers->rdx);
 	} else {
-		write_serial_str("Unhandled syscall!");
+		write_serial_str ("Unhandled syscall!");
 		registers->rax = -ENOIMPL;
 	}
 
@@ -38,5 +39,5 @@ void register_syscall (syscall_handler_t handler, int vector) {
 void init_syscalls (void) {
 	idt_register_handler (0x80, syscall_handler);
 	idt_set_flags (0x80, 0x0E, 3, 0);
-	memset (syscall_handlers, 0, SYSCALL_COUNT * sizeof(syscall_handler_t));
+	memset (syscall_handlers, 0, SYSCALL_COUNT * sizeof (syscall_handler_t));
 }

--- a/kernel/src/kernel/syscall.c
+++ b/kernel/src/kernel/syscall.c
@@ -1,47 +1,21 @@
 #include <kernel/process.h>
 #include <kernel/syscall.h>
-#include <stdio.h>
+#include <kernel/serial.h>
+#include <kernel/error.h>
+
+syscall_handler_t syscall_handlers [SYSCALL_COUNT];
 
 registers_t* syscall_handler (registers_t* registers) {
-	uint64_t syscall_number = registers->rax;
+	uint64_t vector = registers->rax;
 
 	process* current = get_current_process ();
 	if (current) current->p_registers_ptr = registers;
 
-	if (syscall_number == 3) { // sys_read
-		int	   fd = (int)registers->rdi;
-		void*  buf = (void*)registers->rsi;
-		size_t size = (size_t)registers->rdx;
-		int	   error = sys_read (fd, buf, size);
-		registers->rax = (uint64_t)error;
-	} else if (syscall_number == 4) { // sys_write
-		int	   fd = (int)registers->rdi;
-		void*  buf = (void*)registers->rsi;
-		size_t size = (size_t)registers->rdx;
-		if (fd == 1) // temporary
-			printf (buf);
-	} else if (syscall_number == 5) { // sys_open
-		char* filename = (char*)registers->rdi;
-		int	  flags = (int)registers->rsi;
-		int	  mode = (int)registers->rdx;
-		int	  fd = sys_open (filename, flags, mode);
-		registers->rax = (uint64_t)fd;
-	} else if (syscall_number == 6) {
-		int fd = (int)registers->rdi;
-		int error = sys_close (fd);
-		registers->rax = (uint64_t)error;
-	} else if (syscall_number == 39) { // sys_mkdir
-		char* path = (char*)registers->rdi;
-		int	  mode = (int)registers->rsi;
-		int	  error = sys_mkdir (path, mode);
-		registers->rax = (uint64_t)error;
-	} else if (syscall_number == SYSCALL_SYS_FORK) { // sys_fork
-		process* child = NULL;
-		int		 status = process_fork (current, &child);
-		if (status == 0 && child != NULL)
-			registers->rax = child->p_id;
-		else
-			registers->rax = (uint64_t)-1;
+	if (syscall_handlers[vector]) {
+		registers->rax = syscall_handlers[vector](registers->rdi, registers->rsi, registers->rdx);
+	} else {
+		write_serial_str("Unhandled syscall!");
+		registers->rax = -ENOIMPL;
 	}
 
 	return registers;
@@ -56,7 +30,13 @@ uint64_t do_syscall (uint64_t syscall, uint64_t arg1, uint64_t arg2, uint64_t ar
 	return ret;
 }
 
+void register_syscall (syscall_handler_t handler, int vector) {
+	if (vector < 0 || vector >= SYSCALL_COUNT) return;
+	syscall_handlers[vector] = handler;
+}
+
 void init_syscalls (void) {
 	idt_register_handler (0x80, syscall_handler);
 	idt_set_flags (0x80, 0x0E, 3, 0);
+	memset (syscall_handlers, 0, SYSCALL_COUNT * sizeof(syscall_handler_t));
 }

--- a/kernel/src/kernel/syscall.c
+++ b/kernel/src/kernel/syscall.c
@@ -15,7 +15,7 @@ registers_t* syscall_handler (registers_t* registers) {
 	if (syscall_handlers[vector]) {
 		registers->rax = syscall_handlers[vector](registers->rdi, registers->rsi, registers->rdx);
 	} else {
-		write_serial_str ("Unhandled syscall!");
+		write_serial_str ("Unhandled syscall!\n");
 		registers->rax = -ENOIMPL;
 	}
 
@@ -26,7 +26,7 @@ uint64_t do_syscall (uint64_t syscall, uint64_t arg1, uint64_t arg2, uint64_t ar
 	uint64_t ret;
 	__asm__ volatile ("int $0x80"
 					  : "=a"(ret)
-					  : "a"(syscall), "b"(arg1), "c"(arg2), "d"(arg3)
+					  : "a"(syscall), "D"(arg1), "S"(arg2), "d"(arg3)
 					  : "memory");
 	return ret;
 }

--- a/kernel/src/kernel/syscall.c
+++ b/kernel/src/kernel/syscall.c
@@ -31,7 +31,7 @@ uint64_t do_syscall (uint64_t syscall, uint64_t arg1, uint64_t arg2, uint64_t ar
 	return ret;
 }
 
-void register_syscall (syscall_handler_t handler, int vector) {
+void register_syscall (int vector, syscall_handler_t handler) {
 	if (vector < 0 || vector >= SYSCALL_COUNT) return;
 	syscall_handlers[vector] = handler;
 }


### PR DESCRIPTION
Change how syscalls work so that they are registered instead of set as one big if-else/switch statement in syscall handler.