### PR TITLE
(fix) Do not deallocate memory of a process

### DIFF
--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -168,9 +168,6 @@ static uint64_t sys_exit (uint64_t status, uint64_t arg2, uint64_t arg3) {
 	for (int i = 0; i < MAX_FDS; i++)
 		if (current->p_fds[i]) sys_close (i, 0, 0);
 
-	dealloc_by_cr3 (current->p_cr3, 0, 512ll * 512ll * 512ll * 256ll);
-	free_vpages ((void*)(current->p_kstack - STACK_SIZE), STACK_SIZE / PAGE_SIZE);
-
 	return (uint64_t)schedule (get_latest_r_frame ());
 }
 


### PR DESCRIPTION
Fixes an issue where a process exiting may cause the scheduler to perpetually hang.