### PR TITLE
Set up software context switching

### DIFF
--- a/kernel/include/kernel/handlers.h
+++ b/kernel/include/kernel/handlers.h
@@ -4,7 +4,7 @@
 
 #include <kernel/idt.h>
 
-registers_t* handle_gpf (registers_t* registers);
+void handle_gpf (registers_t* registers);
 
 void init_handlers (void);
 

--- a/kernel/include/kernel/hw/timer.h
+++ b/kernel/include/kernel/hw/timer.h
@@ -5,7 +5,7 @@
 
 uint64_t get_current_tick (void);
 
-registers_t* timer_handler (registers_t* registers);
-void		 init_timer (void);
+void timer_handler (registers_t* registers);
+void init_timer (void);
 
 #endif

--- a/kernel/include/kernel/idt.h
+++ b/kernel/include/kernel/idt.h
@@ -30,7 +30,7 @@ typedef struct __attribute__ ((packed)) {
 	uint64_t rip, cs, rflags, rsp, ss;
 } registers_t;
 
-typedef registers_t* (*irq_handler_t) (registers_t*);
+typedef void (*irq_handler_t) (registers_t*);
 
 void init_idt (void);
 void idt_register_handler (int vector, irq_handler_t handler);

--- a/kernel/include/kernel/process.h
+++ b/kernel/include/kernel/process.h
@@ -23,6 +23,7 @@ struct process {
 	struct file* p_fds[MAX_FDS];
 	uintptr_t	 p_heap_base;
 	uintptr_t	 p_heap_sz;
+	uintptr_t	 p_sp;
 };
 
 typedef struct {
@@ -35,7 +36,7 @@ process*	   get_current_process (void);
 int dequeue_process (process_queue* queue, process** result);
 int enqueue_process (process_queue* queue, process* new_process);
 
-registers_t* schedule (registers_t* registers);
+void schedule (registers_t* registers);
 
 int process_fork (process* source_process, process** dest_ptr);
 

--- a/kernel/include/kernel/syscall.h
+++ b/kernel/include/kernel/syscall.h
@@ -19,8 +19,8 @@
 
 typedef uint64_t (*syscall_handler_t) (uint64_t, uint64_t, uint64_t);
 
-registers_t* syscall_handler (registers_t* registers);
-void		 init_syscalls (void);
+void syscall_handler (registers_t* registers);
+void init_syscalls (void);
 
 void		 register_syscall (int vector, syscall_handler_t handler);
 uint64_t	 do_syscall (uint64_t syscall, uint64_t arg1, uint64_t arg2, uint64_t arg3);

--- a/kernel/include/kernel/syscall.h
+++ b/kernel/include/kernel/syscall.h
@@ -6,16 +6,17 @@
 
 #define SYSCALL_COUNT 256
 
-#define SYSCALL_SYS_EXIT   1
-#define SYSCALL_SYS_READ   3
-#define SYSCALL_SYS_WRITE  4
-#define SYSCALL_SYS_OPEN   5
-#define SYSCALL_SYS_CLOSE  6
-#define SYSCALL_SYS_LSEEK  19
-#define SYSCALL_SYS_GETPID 20
-#define SYSCALL_SYS_MKDIR  39
-#define SYSCALL_SYS_BRK	   45
-#define SYSCALL_SYS_FORK   57
+#define SYSCALL_SYS_EXIT	1
+#define SYSCALL_SYS_READ	3
+#define SYSCALL_SYS_WRITE	4
+#define SYSCALL_SYS_OPEN	5
+#define SYSCALL_SYS_CLOSE	6
+#define SYSCALL_SYS_LSEEK	19
+#define SYSCALL_SYS_GETPID	20
+#define SYSCALL_SYS_MKDIR	39
+#define SYSCALL_SYS_BRK		45
+#define SYSCALL_SYS_FORK	57
+#define SYSCALL_SCHED_YIELD 158
 
 typedef uint64_t (*syscall_handler_t) (uint64_t, uint64_t, uint64_t);
 

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -143,7 +143,7 @@ __attribute__ ((noreturn)) void _start_stage2 (void) {
 	}
 
 	for (;;)
-		;
+		do_syscall (SYSCALL_SCHED_YIELD, 0, 0, 0);
 }
 
 static void get_limine_requests (void) {

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -210,6 +210,19 @@ void _start (void) {
 	regs->rflags = 0x202; // IF=1
 
 	stage2_proc->p_registers_ptr = regs;
+
+	extern void ret_from_fork (void);
+	uintptr_t*	init_sp = (uintptr_t*)regs;
+
+	init_sp -= 1;
+	*init_sp = (uintptr_t)ret_from_fork;
+
+	init_sp -= 6;
+	for (int i = 0; i < 6; i++)
+		init_sp[i] = 0;
+
+	stage2_proc->p_sp = (uintptr_t)init_sp;
+
 	enqueue_process (get_ready_queue (), stage2_proc);
 
 	kserial_printf ("\n[Stage 1] Hands off to scheduler.\n");

--- a/kernel/src/kernel/handlers.c
+++ b/kernel/src/kernel/handlers.c
@@ -2,6 +2,7 @@
 #include <kernel/handlers.h>
 
 void handle_gpf (registers_t* registers) {
+	(void)registers;
 	kserial_printf ("\nOopsy! Looks like someone tried to execute a disallowed instruction!");
 	for (;;)
 		;

--- a/kernel/src/kernel/handlers.c
+++ b/kernel/src/kernel/handlers.c
@@ -1,11 +1,10 @@
 #include <kclib/stdio.h>
 #include <kernel/handlers.h>
 
-registers_t* handle_gpf (registers_t* registers) {
+void handle_gpf (registers_t* registers) {
 	kserial_printf ("\nOopsy! Looks like someone tried to execute a disallowed instruction!");
 	for (;;)
 		;
-	return registers; // dead code but shuts up unused var warning
 }
 
 void init_handlers (void) { idt_register_handler (0xD, handle_gpf); }

--- a/kernel/src/kernel/hw/timer.c
+++ b/kernel/src/kernel/hw/timer.c
@@ -6,10 +6,10 @@ uint64_t tick = 0;
 
 uint64_t get_current_tick (void) { return tick; }
 
-registers_t* timer_handler (registers_t* registers) {
+void timer_handler (registers_t* registers) {
 	pic_send_eoi (0);
 	tick++;
-	return schedule (registers);
+	schedule (registers);
 }
 
 void init_timer (void) {

--- a/kernel/src/kernel/idt.c
+++ b/kernel/src/kernel/idt.c
@@ -10,7 +10,7 @@ irq_handler_t interrupt_handlers[256];
 extern void*  isr_stub_table[];
 
 // Declaration of handler for internal use only
-registers_t* kernel_dispatch_interrupt (registers_t* registers);
+void kernel_dispatch_interrupt (registers_t* registers);
 
 static void idt_set_gate (uint8_t vector, void* isr, uint8_t gate_type, uint8_t dpl,
 						  uint8_t present) {
@@ -63,11 +63,11 @@ static void log_registers_to_serial (registers_t* registers) {
 	kserial_printf ("----------------------------------\n\n");
 }
 
-registers_t* kernel_dispatch_interrupt (registers_t* registers) {
+void kernel_dispatch_interrupt (registers_t* registers) {
 	irq_handler_t handler = interrupt_handlers[registers->interrupt_number];
-	if (handler)
-		return handler (registers);
-	else {
+	if (handler) {
+		handler (registers);
+	} else {
 		kserial_printf ("Unhandled interrupt! Hasta la vista");
 		log_registers_to_serial (registers);
 		while (1)

--- a/kernel/src/kernel/isr_setup.s
+++ b/kernel/src/kernel/isr_setup.s
@@ -41,8 +41,6 @@ isr_common_stub:
     movq %rsp, %rdi
     call kernel_dispatch_interrupt
 
-    movq %rax, %rsp
-
     popq %rax
     popq %rbx
     popq %rcx

--- a/kernel/src/kernel/isr_setup.s
+++ b/kernel/src/kernel/isr_setup.s
@@ -41,6 +41,8 @@ isr_common_stub:
     movq %rsp, %rdi
     call kernel_dispatch_interrupt
 
+.global restore_registers_and_iret
+restore_registers_and_iret:
     popq %rax
     popq %rbx
     popq %rcx
@@ -59,6 +61,34 @@ isr_common_stub:
 
     addq $16, %rsp
     iretq
+
+.global switch_to
+switch_to:
+    pushq %rbx
+    pushq %rbp
+    pushq %r12
+    pushq %r13
+    pushq %r14
+    pushq %r15
+    
+    movq %rsp, (%rdi)
+    movq %rsi, %rsp
+    movq %rdx, %cr3
+    
+    popq %r15
+    popq %r14
+    popq %r13
+    popq %r12
+    popq %rbp
+    popq %rbx
+    
+    ret
+
+.global ret_from_fork
+ret_from_fork:
+    jmp restore_registers_and_iret
+
+
 
 
 # here be the isr definitions

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -23,9 +23,6 @@ struct limine_memmap_response* memmap_response_ptr;
 
 uintptr_t kernel_cr3 = 0;
 
-// Handler definition for internal use only
-registers_t* page_fault_handler (registers_t* registers);
-
 /*!
  * Reads the value of the CR3 register, which contains the physical address of the PML4 table.
  * @return The value of the CR3 register.
@@ -239,9 +236,10 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 
 /*!
  * Simple handler for page fault, prints faulting address from CR2
- * @param registers idt-passed registers object
  */
-registers_t* page_fault_handler (registers_t* registers) {
+static void page_fault_handler (registers_t* registers) {
+	(void)registers;
+
 	uint64_t cr2;
 	__asm__ volatile ("mov %%cr2, %0" : "=r"(cr2));
 
@@ -249,8 +247,6 @@ registers_t* page_fault_handler (registers_t* registers) {
 
 	for (;;)
 		;
-
-	return registers;
 }
 
 /*!

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -70,9 +70,12 @@ void schedule (registers_t* registers) {
 	current_process->p_state = TASK_RUNNING;
 	tss_set_stack (current_process->p_kstack);
 
-	uintptr_t prev_sp = 0;
-	if (prev != nullptr) prev_sp = prev->p_sp;
-	switch_to (&prev_sp, upcoming_process->p_sp, upcoming_process->p_cr3);
+	if (prev != nullptr) {
+		switch_to (&prev->p_sp, upcoming_process->p_sp, upcoming_process->p_cr3);
+	} else {
+		uintptr_t dummy_sp;
+		switch_to (&dummy_sp, upcoming_process->p_sp, upcoming_process->p_cr3);
+	}
 }
 
 int process_fork (process* source_process, process** dest_ptr) {

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -82,6 +82,11 @@ void schedule (registers_t* registers) {
 	}
 }
 
+static int do_sched_yield (void) {
+	schedule (get_latest_r_frame ());
+	return 0;
+}
+
 int process_fork (process* source_process, process** dest_ptr) {
 	process* new_process = kmalloc (sizeof (process));
 	if (!new_process) return -ENOMEM;
@@ -201,6 +206,11 @@ static uint64_t sys_getpid (uint64_t arg1, uint64_t arg2, uint64_t arg3) {
 	return current ? current->p_id : 0ull;
 }
 
+static uint64_t sys_sched_yield (uint64_t arg1, uint64_t arg2, uint64_t arg3) {
+	(void)arg1, (void)arg2, (void)arg3;
+	return do_sched_yield ();
+}
+
 void init_process (void) {
 	ready_queue.head = ready_queue.tail = nullptr;
 	next_free_pid = 2ll;
@@ -208,4 +218,5 @@ void init_process (void) {
 	register_syscall (SYSCALL_SYS_EXIT, sys_exit);
 	register_syscall (SYSCALL_SYS_FORK, sys_fork);
 	register_syscall (SYSCALL_SYS_GETPID, sys_getpid);
+	register_syscall (SYSCALL_SCHED_YIELD, sys_sched_yield);
 }

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -46,7 +46,7 @@ int enqueue_process (process_queue* queue, process* new_process) {
 
 process* get_current_process (void) { return current_process; }
 
-registers_t* schedule (registers_t* registers) {
+void schedule (registers_t* registers) {
 	process* upcoming_process = nullptr;
 
 	if (current_process != nullptr && current_process->p_state == TASK_RUNNING) {

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -51,6 +51,7 @@ extern void ret_from_fork (void);
 
 void schedule (registers_t* registers) {
 	process* upcoming_process = nullptr;
+	process* prev = current_process;
 
 	if (current_process != nullptr && current_process->p_state == TASK_RUNNING) {
 		current_process->p_registers_ptr = registers;
@@ -67,9 +68,11 @@ void schedule (registers_t* registers) {
 
 	current_process = upcoming_process;
 	current_process->p_state = TASK_RUNNING;
-	write_cr3 (current_process->p_cr3);
 	tss_set_stack (current_process->p_kstack);
-	// return current_process->p_registers_ptr;
+
+	uintptr_t prev_sp = 0;
+	if (prev != nullptr) prev_sp = prev->p_sp;
+	switch_to (&prev_sp, upcoming_process->p_sp, upcoming_process->p_cr3);
 }
 
 int process_fork (process* source_process, process** dest_ptr) {

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -46,6 +46,9 @@ int enqueue_process (process_queue* queue, process* new_process) {
 
 process* get_current_process (void) { return current_process; }
 
+extern void switch_to (uintptr_t* prev_sp, uintptr_t next_sp, uintptr_t next_cr3);
+extern void ret_from_fork (void);
+
 void schedule (registers_t* registers) {
 	process* upcoming_process = nullptr;
 

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -137,6 +137,19 @@ int process_fork (process* source_process, process** dest_ptr) {
 
 	new_process->p_registers_ptr->rax = 0;
 
+	uintptr_t* stack_ptr = (uintptr_t*)new_process->p_registers_ptr;
+
+	// 'call switch_to' pushes return address
+	stack_ptr -= 1;
+	*stack_ptr = (uintptr_t)ret_from_fork;
+
+	// Push 6 dummy callee-saved registers (rbx, rbp, r12, r13, r14, r15)
+	stack_ptr -= 6;
+	for (int i = 0; i < 6; i++)
+		stack_ptr[i] = 0;
+
+	new_process->p_sp = (uintptr_t)stack_ptr;
+
 	int errno = clone_user_memory (source_process->p_cr3, &new_process->p_cr3);
 	if (errno != 0) {
 		free_vpages (new_kstack, STACK_SIZE / PAGE_SIZE);

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -70,6 +70,10 @@ void schedule (registers_t* registers) {
 	current_process->p_state = TASK_RUNNING;
 	tss_set_stack (current_process->p_kstack);
 
+	// context switching between the same process is buggy because of compiler evaluation gimmicks.
+	// the simplest solution is to just avoid it entirely
+	if (prev == upcoming_process) return;
+
 	if (prev != nullptr) {
 		switch_to (&prev->p_sp, upcoming_process->p_sp, upcoming_process->p_cr3);
 	} else {

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -60,13 +60,13 @@ void schedule (registers_t* registers) {
 	if (upcoming_process == nullptr)
 		for (;;)
 			;
-	if (errno != 0) return registers;
+	if (errno != 0) return;
 
 	current_process = upcoming_process;
 	current_process->p_state = TASK_RUNNING;
 	write_cr3 (current_process->p_cr3);
 	tss_set_stack (current_process->p_kstack);
-	return current_process->p_registers_ptr;
+	// return current_process->p_registers_ptr;
 }
 
 int process_fork (process* source_process, process** dest_ptr) {
@@ -165,7 +165,8 @@ static uint64_t sys_exit (uint64_t status, uint64_t arg2, uint64_t arg3) {
 	for (int i = 0; i < MAX_FDS; i++)
 		if (current->p_fds[i]) sys_close (i, 0, 0);
 
-	return (uint64_t)schedule (get_latest_r_frame ());
+	schedule (get_latest_r_frame ());
+	return 0;
 }
 
 static uint64_t sys_getpid (uint64_t arg1, uint64_t arg2, uint64_t arg3) {

--- a/kernel/src/kernel/syscall.c
+++ b/kernel/src/kernel/syscall.c
@@ -14,9 +14,6 @@ void syscall_handler (registers_t* registers) {
 	process* current = get_current_process ();
 	if (current) current->p_registers_ptr = registers;
 
-	// if (vector == SYSCALL_SYS_EXIT)
-	// 	syscall_handlers[vector](registers->rdi, registers->rsi, registers->rdx);
-
 	if (syscall_handlers[vector]) {
 		registers->rax = syscall_handlers[vector](registers->rdi, registers->rsi, registers->rdx);
 	} else {

--- a/kernel/src/kernel/syscall.c
+++ b/kernel/src/kernel/syscall.c
@@ -7,16 +7,15 @@
 syscall_handler_t syscall_handlers[SYSCALL_COUNT];
 registers_t*	  latest_frame;
 
-registers_t* syscall_handler (registers_t* registers) {
+void syscall_handler (registers_t* registers) {
 	uint64_t vector = registers->rax;
 	latest_frame = registers;
 
 	process* current = get_current_process ();
 	if (current) current->p_registers_ptr = registers;
 
-	if (vector == SYSCALL_SYS_EXIT)
-		return (registers_t*)syscall_handlers[vector](registers->rdi, registers->rsi,
-													  registers->rdx);
+	// if (vector == SYSCALL_SYS_EXIT)
+	// 	syscall_handlers[vector](registers->rdi, registers->rsi, registers->rdx);
 
 	if (syscall_handlers[vector]) {
 		registers->rax = syscall_handlers[vector](registers->rdi, registers->rsi, registers->rdx);
@@ -24,8 +23,6 @@ registers_t* syscall_handler (registers_t* registers) {
 		kserial_printf ("Unhandled syscall 0x%x!\n", vector);
 		registers->rax = -ENOIMPL;
 	}
-
-	return registers;
 }
 
 uint64_t do_syscall (uint64_t syscall, uint64_t arg1, uint64_t arg2, uint64_t arg3) {


### PR DESCRIPTION
This saves cycles over hardware context switching and is way more flexible for where scheduler can be called for.

As a result, sched_yield has also been implemented as a very simplistic call to schedule().