### PR TITLE
Complete the initialisation of HHDM

### DIFF
--- a/kernel/include/kernel/memmgt.h
+++ b/kernel/include/kernel/memmgt.h
@@ -107,7 +107,6 @@ void free_all_vpages_in_range (vaddr_t first, vaddr_t last);
 void alloc_by_cr3 (uint64_t cr3, uintptr_t start, size_t num_pages, bool write);
 void dealloc_by_cr3 (uint64_t cr3, uintptr_t start, size_t num_pages);
 
-void init_hhdm (struct limine_memmap_response* memmap_response);
 void init_memmgt (uint64_t, struct limine_memmap_response*);
 
 void	  walk_pagetable (void);

--- a/kernel/include/kernel/memmgt.h
+++ b/kernel/include/kernel/memmgt.h
@@ -104,7 +104,9 @@ void free_all_vpages_in_range (vaddr_t first, vaddr_t last);
 void alloc_by_cr3 (uint64_t cr3, uintptr_t start, size_t num_pages, bool write);
 void dealloc_by_cr3 (uint64_t cr3, uintptr_t start, size_t num_pages);
 
-void	  init_memmgt (uint64_t, struct limine_memmap_response*);
+void init_hhdm (uint64_t memsz, uint64_t hhdm_offset);
+void init_memmgt (uint64_t, struct limine_memmap_response*);
+
 void	  walk_pagetable (void);
 void*	  get_paddr (void* vaddr);
 uintptr_t get_kernel_cr3 (void);

--- a/kernel/include/kernel/memmgt.h
+++ b/kernel/include/kernel/memmgt.h
@@ -107,7 +107,7 @@ void free_all_vpages_in_range (vaddr_t first, vaddr_t last);
 void alloc_by_cr3 (uint64_t cr3, uintptr_t start, size_t num_pages, bool write);
 void dealloc_by_cr3 (uint64_t cr3, uintptr_t start, size_t num_pages);
 
-void init_hhdm (uint64_t memsz, uint64_t hhdm_offset);
+void init_hhdm (struct limine_memmap_response* memmap_response);
 void init_memmgt (uint64_t, struct limine_memmap_response*);
 
 void	  walk_pagetable (void);

--- a/kernel/include/kernel/memmgt.h
+++ b/kernel/include/kernel/memmgt.h
@@ -8,6 +8,9 @@
 
 #define PAGE_SIZE 4096ull
 
+#define PAGE_ALIGN_DOWN(x) ((x) & ~(PAGE_SIZE - 1))
+#define PAGE_ALIGN_UP(x)   (((x) + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1))
+
 typedef struct {
 	uint64_t present : 1;			 // Page present in memory
 	uint64_t read_write : 1;		 // Read-write flag

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -606,11 +606,16 @@ static uint64_t sys_brk (uint64_t addr, uint64_t arg2, uint64_t arg3) {
  * @param memsz The size of memory available.
  * @param hhdm_offset The higher half direct mapping offset.
  */
-void init_hhdm (uint64_t memsz, uint64_t hhdm_offset) {
-	if (memsz == 0) return;
-	vaddr_t start = get_vaddr_t_from_ptr ((void*)hhdm_offset);
-	vaddr_t end = get_vaddr_t_from_ptr ((void*)(hhdm_offset + memsz - 1));
-	alloc_all_vpages_in_range (start, end, 0);
+void init_hhdm (struct limine_memmap_response* memmap_response) {
+	for (uint64_t i = 0; i < memmap_response->entry_count; i++) {
+		struct limine_memmap_entry* entry = memmap_response->entries[i];
+		if (entry->type == LIMINE_MEMMAP_RESERVED || entry->type == LIMINE_MEMMAP_BAD_MEMORY)
+			continue;
+		vaddr_t start = get_vaddr_t_from_ptr ((void*)PAGE_ALIGN_DOWN (hhdm_offset + entry->base));
+		vaddr_t end = get_vaddr_t_from_ptr (
+			(void*)PAGE_ALIGN_UP (hhdm_offset + entry->base + entry->length - 1));
+		alloc_all_vpages_in_range (start, end, (paddr_t)PAGE_ALIGN_DOWN (entry->base));
+	}
 }
 
 /*!
@@ -645,7 +650,7 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 	pml4_base_ptr[KRNL_PML4_IDX].read_write = 1;
 	pml4_base_ptr[KRNL_PML4_IDX].pdpt_base_address = ((uint64_t)krnl_pdpt_frame) / PAGE_SIZE;
 
-	init_hhdm (addr_size, hhdm_offset);
+	init_hhdm (memmap_response);
 	register_syscall (SYSCALL_SYS_BRK, sys_brk);
 }
 

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -604,7 +604,7 @@ static uint64_t sys_brk (uint64_t addr, uint64_t arg2, uint64_t arg3) {
  * @param memsz The size of memory available.
  * @param hhdm_offset The higher half direct mapping offset.
  */
-void init_hhdm (struct limine_memmap_response* memmap_response) {
+static void init_hhdm (struct limine_memmap_response* memmap_response) {
 	for (uint64_t i = 0; i < memmap_response->entry_count; i++) {
 		struct limine_memmap_entry* entry = memmap_response->entries[i];
 		if (entry->type == LIMINE_MEMMAP_RESERVED || entry->type == LIMINE_MEMMAP_BAD_MEMORY)

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -610,7 +610,7 @@ void init_hhdm (uint64_t memsz, uint64_t hhdm_offset) {
 	if (memsz == 0) return;
 	vaddr_t start = get_vaddr_t_from_ptr ((void*)hhdm_offset);
 	vaddr_t end = get_vaddr_t_from_ptr ((void*)(hhdm_offset + memsz - 1));
-	alloc_all_vpages_in_range(start, end, 0);
+	alloc_all_vpages_in_range (start, end, 0);
 }
 
 /*!

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -183,7 +183,7 @@ static void free_ppages (void* paddr, uint64_t count) {
  */
 static void free_ppage (void* paddr) { free_ppages (paddr, 1); }
 
-static uint64_t init_physical_bitmap (struct limine_memmap_response* memmap_response) {
+static void init_physical_bitmap (struct limine_memmap_response* memmap_response) {
 	uint64_t addr_limit = 0;
 
 	for (uint64_t i = 0; i < memmap_response->entry_count; i++) {
@@ -232,8 +232,6 @@ static uint64_t init_physical_bitmap (struct limine_memmap_response* memmap_resp
 			}
 		}
 	}
-
-	return addr_limit;
 }
 
 /*!
@@ -633,7 +631,7 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 	kernel_cr3 = read_cr3 ();
 
 	// set up bitmap for physical page allocation
-	uint64_t addr_size = init_physical_bitmap (memmap_response);
+	init_physical_bitmap (memmap_response);
 
 	paddr_t user_pdpt_frame = alloc_ppage ();
 	kmemset (get_vaddr_from_frame ((uint64_t)user_pdpt_frame / PAGE_SIZE), 0, PAGE_SIZE);

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -183,7 +183,7 @@ static void free_ppages (void* paddr, uint64_t count) {
  */
 static void free_ppage (void* paddr) { free_ppages (paddr, 1); }
 
-static void init_physical_bitmap (struct limine_memmap_response* memmap_response) {
+static uint64_t init_physical_bitmap (struct limine_memmap_response* memmap_response) {
 	uint64_t addr_limit = 0;
 
 	for (uint64_t i = 0; i < memmap_response->entry_count; i++) {
@@ -232,6 +232,8 @@ static void init_physical_bitmap (struct limine_memmap_response* memmap_response
 			}
 		}
 	}
+
+	return addr_limit;
 }
 
 /*!
@@ -600,6 +602,18 @@ static uint64_t sys_brk (uint64_t addr, uint64_t arg2, uint64_t arg3) {
 }
 
 /*!
+ * Initializes the HHDM at hhdm_offset.
+ * @param memsz The size of memory available.
+ * @param hhdm_offset The higher half direct mapping offset.
+ */
+void init_hhdm (uint64_t memsz, uint64_t hhdm_offset) {
+	if (memsz == 0) return;
+	vaddr_t start = get_vaddr_t_from_ptr ((void*)hhdm_offset);
+	vaddr_t end = get_vaddr_t_from_ptr ((void*)(hhdm_offset + memsz - 1));
+	alloc_all_vpages_in_range(start, end, 0);
+}
+
+/*!
  * Initializes the memory management subsystem.
  * Sets the base pointer for the PML4 table and stores the HHDM offset.
  * @param p_hhdm_offset The higher half direct mapping offset.
@@ -614,7 +628,7 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 	kernel_cr3 = read_cr3 ();
 
 	// set up bitmap for physical page allocation
-	init_physical_bitmap (memmap_response);
+	uint64_t addr_size = init_physical_bitmap (memmap_response);
 
 	paddr_t user_pdpt_frame = alloc_ppage ();
 	kmemset (get_vaddr_from_frame ((uint64_t)user_pdpt_frame / PAGE_SIZE), 0, PAGE_SIZE);
@@ -631,6 +645,7 @@ void init_memmgt (uint64_t p_hhdm_offset, struct limine_memmap_response* memmap_
 	pml4_base_ptr[KRNL_PML4_IDX].read_write = 1;
 	pml4_base_ptr[KRNL_PML4_IDX].pdpt_base_address = ((uint64_t)krnl_pdpt_frame) / PAGE_SIZE;
 
+	init_hhdm (addr_size, hhdm_offset);
 	register_syscall (SYSCALL_SYS_BRK, sys_brk);
 }
 

--- a/kernel/src/kernel/memmgt.c
+++ b/kernel/src/kernel/memmgt.c
@@ -611,7 +611,7 @@ static void init_hhdm (struct limine_memmap_response* memmap_response) {
 			continue;
 		vaddr_t start = get_vaddr_t_from_ptr ((void*)PAGE_ALIGN_DOWN (hhdm_offset + entry->base));
 		vaddr_t end = get_vaddr_t_from_ptr (
-			(void*)PAGE_ALIGN_UP (hhdm_offset + entry->base + entry->length - 1));
+			(void*)PAGE_ALIGN_DOWN (hhdm_offset + entry->base + entry->length - 1));
 		alloc_all_vpages_in_range (start, end, (paddr_t)PAGE_ALIGN_DOWN (entry->base));
 	}
 }


### PR DESCRIPTION
HHDM is mandatorily created for all parts of memory except those that limine says are 'reserved' or 'bad memory'.