### PR TITLE
License COS under GPLv2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ chmod +x build.sh
 This will generate a file `image.iso` inside your working directory. Use VMWare or your favourite VM emulator (or put it on a liveCD if you're brave enough) to run and test it out. Or run `qemu.sh` to run it on QEMU.
 
 ![An image of COS saying 'Hello, world!'](images/hello%20world%20with%20cosh.png)
+
+## License
+
+This project is released under the GPLv2 license. To find out more, read [LICENSE](LICENSE).

--- a/kernel/include/kclib/ctype.h
+++ b/kernel/include/kclib/ctype.h
@@ -1,3 +1,19 @@
+/*
+ * ctype.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 int isalnum (int c);

--- a/kernel/include/kclib/stdio.h
+++ b/kernel/include/kclib/stdio.h
@@ -1,3 +1,19 @@
+/*
+ * stdio.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdarg.h>

--- a/kernel/include/kclib/string.h
+++ b/kernel/include/kclib/string.h
@@ -1,3 +1,19 @@
+/*
+ * string.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/kernel/include/kernel/acpi/acpi.h
+++ b/kernel/include/kernel/acpi/acpi.h
@@ -1,3 +1,19 @@
+/*
+ * acpi.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/acpi/acpi_common.h
+++ b/kernel/include/kernel/acpi/acpi_common.h
@@ -1,3 +1,19 @@
+/*
+ * acpi_common.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/acpi/fadt.h
+++ b/kernel/include/kernel/acpi/fadt.h
@@ -1,3 +1,19 @@
+/*
+ * fadt.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/acpi/acpi_common.h>

--- a/kernel/include/kernel/acpi/madt.h
+++ b/kernel/include/kernel/acpi/madt.h
@@ -1,3 +1,19 @@
+/*
+ * madt.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/acpi/acpi_common.h>

--- a/kernel/include/kernel/acpi/rsdp.h
+++ b/kernel/include/kernel/acpi/rsdp.h
@@ -1,3 +1,19 @@
+/*
+ * rsdp.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/acpi/rsdt.h
+++ b/kernel/include/kernel/acpi/rsdt.h
@@ -1,3 +1,19 @@
+/*
+ * rsdt.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 void init_rsdt (uint32_t rsdt_base_ptr);

--- a/kernel/include/kernel/con/ansi.h
+++ b/kernel/include/kernel/con/ansi.h
@@ -1,3 +1,19 @@
+/*
+ * ansi.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/con/con_ds.h>

--- a/kernel/include/kernel/con/con.h
+++ b/kernel/include/kernel/con/con.h
@@ -1,3 +1,19 @@
+/*
+ * con.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/fs/ioctl.h>

--- a/kernel/include/kernel/con/con_ds.h
+++ b/kernel/include/kernel/con/con_ds.h
@@ -1,3 +1,19 @@
+/*
+ * con_ds.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/kernel/include/kernel/elf.h
+++ b/kernel/include/kernel/elf.h
@@ -1,3 +1,19 @@
+/*
+ * elf.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/process.h>

--- a/kernel/include/kernel/error.h
+++ b/kernel/include/kernel/error.h
@@ -1,3 +1,19 @@
+/*
+ * error.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #define EPERM			1	/* Not owner */

--- a/kernel/include/kernel/exec.h
+++ b/kernel/include/kernel/exec.h
@@ -1,3 +1,19 @@
+/*
+ * exec.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/fs/chardev.h
+++ b/kernel/include/kernel/fs/chardev.h
@@ -1,3 +1,19 @@
+/*
+ * chardev.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/fs/vfs.h>

--- a/kernel/include/kernel/fs/cpio.h
+++ b/kernel/include/kernel/fs/cpio.h
@@ -1,3 +1,19 @@
+/*
+ * cpio.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/fs/vfs.h>

--- a/kernel/include/kernel/fs/fcntl.h
+++ b/kernel/include/kernel/fs/fcntl.h
@@ -1,3 +1,19 @@
+/*
+ * fcntl.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 // Flags for fctnl

--- a/kernel/include/kernel/fs/ioctl.h
+++ b/kernel/include/kernel/fs/ioctl.h
@@ -1,3 +1,19 @@
+/*
+ * ioctl.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #define TIOCGWINSZ 0x5413

--- a/kernel/include/kernel/fs/ramfs.h
+++ b/kernel/include/kernel/fs/ramfs.h
@@ -1,3 +1,19 @@
+/*
+ * ramfs.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/fs/vfs.h>

--- a/kernel/include/kernel/fs/stat.h
+++ b/kernel/include/kernel/fs/stat.h
@@ -1,3 +1,19 @@
+/*
+ * stat.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/fs/vfs.h
+++ b/kernel/include/kernel/fs/vfs.h
@@ -1,3 +1,19 @@
+/*
+ * vfs.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/fs/stat.h>

--- a/kernel/include/kernel/gdt.h
+++ b/kernel/include/kernel/gdt.h
@@ -1,3 +1,19 @@
+/*
+ * gdt.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/graphics.h
+++ b/kernel/include/kernel/graphics.h
@@ -1,3 +1,19 @@
+/*
+ * graphics.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/limine.h>

--- a/kernel/include/kernel/handlers.h
+++ b/kernel/include/kernel/handlers.h
@@ -1,3 +1,19 @@
+/*
+ * handlers.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/idt.h>

--- a/kernel/include/kernel/hardfonts/classic.h
+++ b/kernel/include/kernel/hardfonts/classic.h
@@ -1,3 +1,19 @@
+/*
+ * classic.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 unsigned char* glyph (char index);

--- a/kernel/include/kernel/hw/cpu_local.h
+++ b/kernel/include/kernel/hw/cpu_local.h
@@ -1,3 +1,19 @@
+/*
+ * cpu_local.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include <stdint.h>
 

--- a/kernel/include/kernel/hw/keyboard.h
+++ b/kernel/include/kernel/hw/keyboard.h
@@ -1,3 +1,19 @@
+/*
+ * keyboard.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/hw/keypress_map.h
+++ b/kernel/include/kernel/hw/keypress_map.h
@@ -1,3 +1,19 @@
+/*
+ * keypress_map.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 constexpr unsigned char kb_action_escape = 0x80;

--- a/kernel/include/kernel/hw/pic.h
+++ b/kernel/include/kernel/hw/pic.h
@@ -1,3 +1,19 @@
+/*
+ * pic.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/io.h>

--- a/kernel/include/kernel/hw/timer.h
+++ b/kernel/include/kernel/hw/timer.h
@@ -1,3 +1,19 @@
+/*
+ * timer.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/idt.h>

--- a/kernel/include/kernel/idt.h
+++ b/kernel/include/kernel/idt.h
@@ -1,3 +1,19 @@
+/*
+ * idt.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/io.h
+++ b/kernel/include/kernel/io.h
@@ -1,3 +1,19 @@
+/*
+ * io.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/memmgt.h
+++ b/kernel/include/kernel/memmgt.h
@@ -1,3 +1,19 @@
+/*
+ * memmgt.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/limine.h>

--- a/kernel/include/kernel/memory/pmm.h
+++ b/kernel/include/kernel/memory/pmm.h
@@ -1,3 +1,19 @@
+/*
+ * pmm.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/memmgt.h>

--- a/kernel/include/kernel/process.h
+++ b/kernel/include/kernel/process.h
@@ -1,3 +1,19 @@
+/*
+ * process.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/fs/vfs.h>

--- a/kernel/include/kernel/serial.h
+++ b/kernel/include/kernel/serial.h
@@ -1,3 +1,19 @@
+/*
+ * serial.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #define SERIAL_COM_1 0x3F8

--- a/kernel/include/kernel/signal.h
+++ b/kernel/include/kernel/signal.h
@@ -1,3 +1,19 @@
+/*
+ * signal.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/kernel/stack.h
+++ b/kernel/include/kernel/stack.h
@@ -1,3 +1,19 @@
+/*
+ * stack.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include <stdint.h>
 

--- a/kernel/include/kernel/syscall.h
+++ b/kernel/include/kernel/syscall.h
@@ -1,3 +1,19 @@
+/*
+ * syscall.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/idt.h>

--- a/kernel/include/utils/charqueue.h
+++ b/kernel/include/utils/charqueue.h
@@ -1,3 +1,19 @@
+/*
+ * charqueue.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <kernel/memmgt.h>

--- a/kernel/include/utils/deque.h
+++ b/kernel/include/utils/deque.h
@@ -1,3 +1,19 @@
+/*
+ * deque.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/kernel/include/utils/hashmap32.h
+++ b/kernel/include/utils/hashmap32.h
@@ -1,3 +1,19 @@
+/*
+ * hashmap32.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/kernel/include/utils/spinlock.h
+++ b/kernel/include/utils/spinlock.h
@@ -1,3 +1,19 @@
+/*
+ * spinlock.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stdint.h>

--- a/kernel/include/utils/varray.h
+++ b/kernel/include/utils/varray.h
@@ -1,3 +1,19 @@
+/*
+ * varray.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/kernel/src/kclib/ctype.c
+++ b/kernel/src/kclib/ctype.c
@@ -1,3 +1,19 @@
+/*
+ * ctype.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/ctype.h>
 
 /*!

--- a/kernel/src/kclib/memory/memccpy.c
+++ b/kernel/src/kclib/memory/memccpy.c
@@ -1,3 +1,19 @@
+/*
+ * memccpy.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/memory/memchr.c
+++ b/kernel/src/kclib/memory/memchr.c
@@ -1,3 +1,19 @@
+/*
+ * memchr.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/memory/memcmp.c
+++ b/kernel/src/kclib/memory/memcmp.c
@@ -1,3 +1,19 @@
+/*
+ * memcmp.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/memory/memcpy.c
+++ b/kernel/src/kclib/memory/memcpy.c
@@ -1,3 +1,19 @@
+/*
+ * memcpy.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/memory/memmove.c
+++ b/kernel/src/kclib/memory/memmove.c
@@ -1,3 +1,19 @@
+/*
+ * memmove.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/memory/memset.c
+++ b/kernel/src/kclib/memory/memset.c
@@ -1,3 +1,19 @@
+/*
+ * memset.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/stdio.c
+++ b/kernel/src/kclib/stdio.c
@@ -1,3 +1,19 @@
+/*
+ * stdio.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/stdio.h>
 #include <kclib/string.h>
 #include <kernel/con/con.h>

--- a/kernel/src/kclib/string.c
+++ b/kernel/src/kclib/string.c
@@ -1,3 +1,19 @@
+/*
+ * string.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strcat.c
+++ b/kernel/src/kclib/string/strcat.c
@@ -1,3 +1,19 @@
+/*
+ * strcat.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strchr.c
+++ b/kernel/src/kclib/string/strchr.c
@@ -1,3 +1,19 @@
+/*
+ * strchr.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strcmp.c
+++ b/kernel/src/kclib/string/strcmp.c
@@ -1,3 +1,19 @@
+/*
+ * strcmp.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strcpy.c
+++ b/kernel/src/kclib/string/strcpy.c
@@ -1,3 +1,19 @@
+/*
+ * strcpy.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 

--- a/kernel/src/kclib/string/strcspn.c
+++ b/kernel/src/kclib/string/strcspn.c
@@ -1,3 +1,19 @@
+/*
+ * strcspn.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strdup.c
+++ b/kernel/src/kclib/string/strdup.c
@@ -1,3 +1,19 @@
+/*
+ * strdup.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <liballoc/liballoc.h>
 

--- a/kernel/src/kclib/string/strlen.c
+++ b/kernel/src/kclib/string/strlen.c
@@ -1,3 +1,19 @@
+/*
+ * strlen.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strpbrk.c
+++ b/kernel/src/kclib/string/strpbrk.c
@@ -1,3 +1,19 @@
+/*
+ * strpbrk.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strrchr.c
+++ b/kernel/src/kclib/string/strrchr.c
@@ -1,3 +1,19 @@
+/*
+ * strrchr.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strspn.c
+++ b/kernel/src/kclib/string/strspn.c
@@ -1,3 +1,19 @@
+/*
+ * strspn.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strstr.c
+++ b/kernel/src/kclib/string/strstr.c
@@ -1,3 +1,19 @@
+/*
+ * strstr.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kclib/string/strtok.c
+++ b/kernel/src/kclib/string/strtok.c
@@ -1,3 +1,19 @@
+/*
+ * strtok.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 
 /*!

--- a/kernel/src/kernel/acpi/acpi_allocate_table.c
+++ b/kernel/src/kernel/acpi/acpi_allocate_table.c
@@ -1,3 +1,19 @@
+/*
+ * acpi_allocate_table.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/acpi/acpi_common.h>
 #include <kernel/memmgt.h>
 

--- a/kernel/src/kernel/acpi/acpi_data_length.c
+++ b/kernel/src/kernel/acpi/acpi_data_length.c
@@ -1,3 +1,19 @@
+/*
+ * acpi_data_length.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/acpi/acpi_common.h>
 
 /*!

--- a/kernel/src/kernel/acpi/acpi_validate_checksum.c
+++ b/kernel/src/kernel/acpi/acpi_validate_checksum.c
@@ -1,3 +1,19 @@
+/*
+ * acpi_validate_checksum.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/acpi/acpi_common.h>
 
 /*!

--- a/kernel/src/kernel/acpi/fadt.c
+++ b/kernel/src/kernel/acpi/fadt.c
@@ -1,3 +1,19 @@
+/*
+ * fadt.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/acpi/acpi_common.h>
 #include <kernel/acpi/fadt.h>

--- a/kernel/src/kernel/acpi/init_acpi.c
+++ b/kernel/src/kernel/acpi/init_acpi.c
@@ -1,3 +1,19 @@
+/*
+ * init_acpi.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/acpi/acpi.h>
 #include <kernel/acpi/rsdp.h>
 #include <kernel/acpi/rsdt.h>

--- a/kernel/src/kernel/acpi/madt.c
+++ b/kernel/src/kernel/acpi/madt.c
@@ -1,3 +1,19 @@
+/*
+ * madt.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/acpi/madt.h>
 #include <liballoc/liballoc.h>

--- a/kernel/src/kernel/acpi/rsdp.c
+++ b/kernel/src/kernel/acpi/rsdp.c
@@ -1,3 +1,19 @@
+/*
+ * rsdp.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/acpi/rsdp.h>
 #include <kernel/memmgt.h>

--- a/kernel/src/kernel/acpi/rsdt.c
+++ b/kernel/src/kernel/acpi/rsdt.c
@@ -1,3 +1,19 @@
+/*
+ * rsdt.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/stdio.h>
 #include <kclib/string.h>
 #include <kernel/acpi/fadt.h>

--- a/kernel/src/kernel/con/ansi.c
+++ b/kernel/src/kernel/con/ansi.c
@@ -1,3 +1,19 @@
+/*
+ * ansi.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/con/ansi.h>
 #include <kernel/con/con.h>

--- a/kernel/src/kernel/con/con.c
+++ b/kernel/src/kernel/con/con.c
@@ -1,3 +1,19 @@
+/*
+ * con.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/con/ansi.h>
 #include <kernel/con/con.h>
 #include <kernel/con/con_ds.h>

--- a/kernel/src/kernel/con/con_ds.c
+++ b/kernel/src/kernel/con/con_ds.c
@@ -1,3 +1,19 @@
+/*
+ * con_ds.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/con/con_ds.h>
 #include <kernel/error.h>

--- a/kernel/src/kernel/elf.c
+++ b/kernel/src/kernel/elf.c
@@ -1,3 +1,19 @@
+/*
+ * elf.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/stdio.h>
 #include <kclib/string.h>
 #include <kernel/elf.h>

--- a/kernel/src/kernel/entry.c
+++ b/kernel/src/kernel/entry.c
@@ -1,3 +1,19 @@
+/*
+ * entry.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/stdio.h>
 #include <kclib/string.h>
 #include <kernel/acpi/acpi.h>

--- a/kernel/src/kernel/fs/chardev/chardev.c
+++ b/kernel/src/kernel/fs/chardev/chardev.c
@@ -1,3 +1,19 @@
+/*
+ * chardev.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "kernel/fs/vfs.h"
 #include <kclib/ctype.h>
 #include <kclib/stdio.h>

--- a/kernel/src/kernel/fs/cpio/cpio.c
+++ b/kernel/src/kernel/fs/cpio/cpio.c
@@ -1,3 +1,19 @@
+/*
+ * cpio.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/ctype.h>
 #include <kclib/stdio.h>
 #include <kclib/string.h>

--- a/kernel/src/kernel/fs/ramfs/ramfs.c
+++ b/kernel/src/kernel/fs/ramfs/ramfs.c
@@ -1,3 +1,19 @@
+/*
+ * ramfs.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/fs/ramfs.h>

--- a/kernel/src/kernel/fs/vfs/chdir.c
+++ b/kernel/src/kernel/fs/vfs/chdir.c
@@ -1,3 +1,19 @@
+/*
+ * chdir.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/fs/vfs/close.c
+++ b/kernel/src/kernel/fs/vfs/close.c
@@ -1,3 +1,19 @@
+/*
+ * close.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/fs/vfs/create.c
+++ b/kernel/src/kernel/fs/vfs/create.c
@@ -1,3 +1,19 @@
+/*
+ * create.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>

--- a/kernel/src/kernel/fs/vfs/filename_has_invalid_chars.c
+++ b/kernel/src/kernel/fs/vfs/filename_has_invalid_chars.c
@@ -1,3 +1,19 @@
+/*
+ * filename_has_invalid_chars.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/ctype.h>
 #include <kernel/fs/vfs.h>
 

--- a/kernel/src/kernel/fs/vfs/fstat.c
+++ b/kernel/src/kernel/fs/vfs/fstat.c
@@ -1,3 +1,19 @@
+/*
+ * fstat.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/fs/vfs/getcwd.c
+++ b/kernel/src/kernel/fs/vfs/getcwd.c
@@ -1,3 +1,19 @@
+/*
+ * getcwd.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>

--- a/kernel/src/kernel/fs/vfs/getdents.c
+++ b/kernel/src/kernel/fs/vfs/getdents.c
@@ -1,3 +1,19 @@
+/*
+ * getdents.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/fs/vfs/ioctl.c
+++ b/kernel/src/kernel/fs/vfs/ioctl.c
@@ -1,3 +1,19 @@
+/*
+ * ioctl.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/fs/vfs/lookup.c
+++ b/kernel/src/kernel/fs/vfs/lookup.c
@@ -1,3 +1,19 @@
+/*
+ * lookup.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>

--- a/kernel/src/kernel/fs/vfs/mkdir.c
+++ b/kernel/src/kernel/fs/vfs/mkdir.c
@@ -1,3 +1,19 @@
+/*
+ * mkdir.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/ctype.h>
 #include <kclib/string.h>
 #include <kernel/error.h>

--- a/kernel/src/kernel/fs/vfs/open.c
+++ b/kernel/src/kernel/fs/vfs/open.c
@@ -1,3 +1,19 @@
+/*
+ * open.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>

--- a/kernel/src/kernel/fs/vfs/read.c
+++ b/kernel/src/kernel/fs/vfs/read.c
@@ -1,3 +1,19 @@
+/*
+ * read.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/fs/vfs/seek.c
+++ b/kernel/src/kernel/fs/vfs/seek.c
@@ -1,3 +1,19 @@
+/*
+ * seek.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/fs/vfs/stat.c
+++ b/kernel/src/kernel/fs/vfs/stat.c
@@ -1,3 +1,19 @@
+/*
+ * stat.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>

--- a/kernel/src/kernel/fs/vfs/vfs.c
+++ b/kernel/src/kernel/fs/vfs/vfs.c
@@ -1,3 +1,19 @@
+/*
+ * vfs.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/ctype.h>
 #include <kclib/string.h>
 #include <kernel/error.h>

--- a/kernel/src/kernel/fs/vfs/vfs_resolve_parent.c
+++ b/kernel/src/kernel/fs/vfs/vfs_resolve_parent.c
@@ -1,3 +1,19 @@
+/*
+ * vfs_resolve_parent.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>

--- a/kernel/src/kernel/fs/vfs/write.c
+++ b/kernel/src/kernel/fs/vfs/write.c
@@ -1,3 +1,19 @@
+/*
+ * write.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/error.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/gdt.c
+++ b/kernel/src/kernel/gdt.c
@@ -1,3 +1,19 @@
+/*
+ * gdt.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/gdt.h>
 #include <kernel/stack.h>

--- a/kernel/src/kernel/gdt.s
+++ b/kernel/src/kernel/gdt.s
@@ -1,3 +1,19 @@
+/*
+ * gdt.s
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 .text
 .code64
 

--- a/kernel/src/kernel/graphics.c
+++ b/kernel/src/kernel/graphics.c
@@ -1,3 +1,19 @@
+/*
+ * graphics.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/stdio.h>
 #include <kernel/graphics.h>
 #include <kernel/memmgt.h>

--- a/kernel/src/kernel/handlers.c
+++ b/kernel/src/kernel/handlers.c
@@ -1,3 +1,19 @@
+/*
+ * handlers.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/stdio.h>
 #include <kernel/handlers.h>
 #include <kernel/idt.h>

--- a/kernel/src/kernel/hardfonts/classic.c
+++ b/kernel/src/kernel/hardfonts/classic.c
@@ -1,3 +1,19 @@
+/*
+ * classic.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/ctype.h>
 #include <kernel/hardfonts/classic.h>
 #include <stddef.h>

--- a/kernel/src/kernel/hw/cpu_local.c
+++ b/kernel/src/kernel/hw/cpu_local.c
@@ -1,3 +1,19 @@
+/*
+ * cpu_local.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/hw/cpu_local.h>
 #include <kernel/io.h>
 

--- a/kernel/src/kernel/hw/keyboard.c
+++ b/kernel/src/kernel/hw/keyboard.c
@@ -1,3 +1,19 @@
+/*
+ * keyboard.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/con/con.h>
 #include <kernel/error.h>

--- a/kernel/src/kernel/hw/keypress.c
+++ b/kernel/src/kernel/hw/keypress.c
@@ -1,3 +1,19 @@
+/*
+ * keypress.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/ctype.h>
 #include <kernel/hw/keypress_map.h>
 

--- a/kernel/src/kernel/hw/pic.c
+++ b/kernel/src/kernel/hw/pic.c
@@ -1,3 +1,18 @@
+/*
+ * pic.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
 
 #include <kernel/hw/pic.h>
 

--- a/kernel/src/kernel/hw/timer.c
+++ b/kernel/src/kernel/hw/timer.c
@@ -1,3 +1,19 @@
+/*
+ * timer.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/hw/pic.h>
 #include <kernel/hw/timer.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/idt.c
+++ b/kernel/src/kernel/idt.c
@@ -1,3 +1,18 @@
+/*
+ * idt.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
 
 #include <kclib/stdio.h>
 #include <kclib/string.h>

--- a/kernel/src/kernel/io.c
+++ b/kernel/src/kernel/io.c
@@ -1,3 +1,18 @@
+/*
+ * io.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
 
 #include <kernel/io.h>
 

--- a/kernel/src/kernel/isr_setup.s
+++ b/kernel/src/kernel/isr_setup.s
@@ -1,3 +1,19 @@
+/*
+ * isr_setup.s
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 
 # macros for isr setup
 

--- a/kernel/src/kernel/limine_requests.c
+++ b/kernel/src/kernel/limine_requests.c
@@ -1,3 +1,19 @@
+/*
+ * limine_requests.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/limine.h>
 
 __attribute__ ((used, section (".limine_requests"))) static volatile LIMINE_BASE_REVISION (3);

--- a/kernel/src/kernel/memory/clone_user_memory.c
+++ b/kernel/src/kernel/memory/clone_user_memory.c
@@ -1,3 +1,19 @@
+/*
+ * clone_user_memory.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/memmgt.h>

--- a/kernel/src/kernel/memory/cr3.c
+++ b/kernel/src/kernel/memory/cr3.c
@@ -1,3 +1,19 @@
+/*
+ * cr3.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/memmgt.h>
 
 /*!

--- a/kernel/src/kernel/memory/memmgt.c
+++ b/kernel/src/kernel/memory/memmgt.c
@@ -1,3 +1,19 @@
+/*
+ * memmgt.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/stdio.h>
 #include <kclib/string.h>
 #include <kernel/error.h>

--- a/kernel/src/kernel/memory/pmm.c
+++ b/kernel/src/kernel/memory/pmm.c
@@ -1,3 +1,19 @@
+/*
+ * pmm.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/stdio.h>
 #include <kclib/string.h>
 #include <kernel/memmgt.h>

--- a/kernel/src/kernel/memory/vaddr.c
+++ b/kernel/src/kernel/memory/vaddr.c
@@ -1,3 +1,19 @@
+/*
+ * vaddr.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/memmgt.h>
 
 /*!

--- a/kernel/src/kernel/memory/vmm.c
+++ b/kernel/src/kernel/memory/vmm.c
@@ -1,3 +1,19 @@
+/*
+ * vmm.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/memmgt.h>
 #include <kernel/memory/pmm.h>

--- a/kernel/src/kernel/process.c
+++ b/kernel/src/kernel/process.c
@@ -1,3 +1,19 @@
+/*
+ * process.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/gdt.h>

--- a/kernel/src/kernel/serial.c
+++ b/kernel/src/kernel/serial.c
@@ -1,3 +1,18 @@
+/*
+ * serial.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
 
 #include <kernel/serial.h>
 

--- a/kernel/src/kernel/signal.c
+++ b/kernel/src/kernel/signal.c
@@ -1,3 +1,19 @@
+/*
+ * signal.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/process.h>

--- a/kernel/src/kernel/signal_trampoline.s
+++ b/kernel/src/kernel/signal_trampoline.s
@@ -1,3 +1,19 @@
+/*
+ * signal_trampoline.s
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 .global signal_trampoline_start
 .global signal_trampoline_end
 

--- a/kernel/src/kernel/sse.s
+++ b/kernel/src/kernel/sse.s
@@ -1,3 +1,19 @@
+/*
+ * sse.s
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 .text
 .code64
 

--- a/kernel/src/kernel/stack.c
+++ b/kernel/src/kernel/stack.c
@@ -1,3 +1,19 @@
+/*
+ * stack.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/stack.h>
 #include <stdint.h>
 

--- a/kernel/src/kernel/sys/execve.c
+++ b/kernel/src/kernel/sys/execve.c
@@ -1,3 +1,19 @@
+/*
+ * execve.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/elf.h>
 #include <kernel/error.h>

--- a/kernel/src/kernel/syscall.c
+++ b/kernel/src/kernel/syscall.c
@@ -1,3 +1,19 @@
+/*
+ * syscall.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/stdio.h>
 #include <kclib/string.h>
 #include <kernel/error.h>

--- a/kernel/src/kernel/syscall_entry.s
+++ b/kernel/src/kernel/syscall_entry.s
@@ -1,3 +1,19 @@
+/*
+ * syscall_entry.s
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 .text
 .code64
 .global syscall_entry

--- a/kernel/src/liballoc/liballoc.c
+++ b/kernel/src/liballoc/liballoc.c
@@ -1,3 +1,19 @@
+/*
+ * liballoc.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <liballoc/liballoc.h>
 
 /**  Durand's Amazing Super Duper Memory functions.  */

--- a/kernel/src/utils/charqueue.c
+++ b/kernel/src/utils/charqueue.c
@@ -1,3 +1,19 @@
+/*
+ * charqueue.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kclib/string.h>
 #include <kernel/error.h>
 #include <kernel/memmgt.h>

--- a/kernel/src/utils/deque.c
+++ b/kernel/src/utils/deque.c
@@ -1,3 +1,19 @@
+/*
+ * deque.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/error.h>
 #include <liballoc/liballoc.h>
 #include <utils/deque.h>

--- a/kernel/src/utils/hashmap32.c
+++ b/kernel/src/utils/hashmap32.c
@@ -1,3 +1,19 @@
+/*
+ * hashmap32.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <liballoc/liballoc.h>
 #include <utils/hashmap32.h>
 #include <utils/spinlock.h>

--- a/kernel/src/utils/spinlock.c
+++ b/kernel/src/utils/spinlock.c
@@ -1,3 +1,19 @@
+/*
+ * spinlock.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <kernel/io.h>
 #include <utils/spinlock.h>
 

--- a/kernel/src/utils/varray.c
+++ b/kernel/src/utils/varray.c
@@ -1,3 +1,19 @@
+/*
+ * varray.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <liballoc/liballoc.h>
 #include <utils/varray.h>
 

--- a/lib/cos/include/arch/x86_64-cos/fcntl.h
+++ b/lib/cos/include/arch/x86_64-cos/fcntl.h
@@ -1,3 +1,19 @@
+/*
+ * fcntl.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #define O_RDONLY 0x0000

--- a/lib/cos/include/arch/x86_64-cos/syscalls.h
+++ b/lib/cos/include/arch/x86_64-cos/syscalls.h
@@ -1,3 +1,19 @@
+/*
+ * syscalls.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <errno.h>

--- a/lib/cos/include/arch/x86_64-cos/unistd.h
+++ b/lib/cos/include/arch/x86_64-cos/unistd.h
@@ -1,3 +1,19 @@
+/*
+ * unistd.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/lib/cos/include/sys/ioctl.h
+++ b/lib/cos/include/sys/ioctl.h
@@ -1,3 +1,19 @@
+/*
+ * ioctl.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <sys/types.h>

--- a/lib/cos/src/_exit.c
+++ b/lib/cos/src/_exit.c
@@ -1,3 +1,19 @@
+/*
+ * _exit.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/brk.c
+++ b/lib/cos/src/brk.c
@@ -1,3 +1,19 @@
+/*
+ * brk.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/chdir.c
+++ b/lib/cos/src/chdir.c
@@ -1,3 +1,19 @@
+/*
+ * chdir.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/close.c
+++ b/lib/cos/src/close.c
@@ -1,3 +1,19 @@
+/*
+ * close.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/execve.c
+++ b/lib/cos/src/execve.c
@@ -1,3 +1,19 @@
+/*
+ * execve.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 #include <stdint.h>

--- a/lib/cos/src/fork.c
+++ b/lib/cos/src/fork.c
@@ -1,3 +1,19 @@
+/*
+ * fork.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/getcwd.c
+++ b/lib/cos/src/getcwd.c
@@ -1,3 +1,19 @@
+/*
+ * getcwd.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/getdents.c
+++ b/lib/cos/src/getdents.c
@@ -1,3 +1,19 @@
+/*
+ * getdents.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/getpid.c
+++ b/lib/cos/src/getpid.c
@@ -1,3 +1,19 @@
+/*
+ * getpid.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/ioctl.c
+++ b/lib/cos/src/ioctl.c
@@ -1,3 +1,19 @@
+/*
+ * ioctl.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <stdarg.h>
 #include <sys/ioctl.h>

--- a/lib/cos/src/kill.c
+++ b/lib/cos/src/kill.c
@@ -1,3 +1,19 @@
+/*
+ * kill.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <sys/signal.h>
 

--- a/lib/cos/src/lseek.c
+++ b/lib/cos/src/lseek.c
@@ -1,3 +1,19 @@
+/*
+ * lseek.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/mkdir.c
+++ b/lib/cos/src/mkdir.c
@@ -1,3 +1,19 @@
+/*
+ * mkdir.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/open.c
+++ b/lib/cos/src/open.c
@@ -1,3 +1,19 @@
+/*
+ * open.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/fcntl.h>
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>

--- a/lib/cos/src/read.c
+++ b/lib/cos/src/read.c
@@ -1,3 +1,19 @@
+/*
+ * read.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/sbrk.c
+++ b/lib/cos/src/sbrk.c
@@ -1,3 +1,19 @@
+/*
+ * sbrk.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/unistd.h>
 #include <errno.h>
 #include <sys/types.h>

--- a/lib/cos/src/sched_yield.c
+++ b/lib/cos/src/sched_yield.c
@@ -1,3 +1,19 @@
+/*
+ * sched_yield.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/lib/cos/src/sigaction.c
+++ b/lib/cos/src/sigaction.c
@@ -1,3 +1,19 @@
+/*
+ * sigaction.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <sys/signal.h>
 

--- a/lib/cos/src/sigprocmask.c
+++ b/lib/cos/src/sigprocmask.c
@@ -1,3 +1,19 @@
+/*
+ * sigprocmask.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <errno.h>
 #include <sys/signal.h>
 

--- a/lib/cos/src/stat.c
+++ b/lib/cos/src/stat.c
@@ -1,3 +1,19 @@
+/*
+ * stat.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 #include <sys/stat.h>

--- a/lib/cos/src/stubs.c
+++ b/lib/cos/src/stubs.c
@@ -1,3 +1,19 @@
+/*
+ * stubs.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <errno.h>
 #include <stdarg.h>
 #include <sys/stat.h>

--- a/lib/cos/src/wait.c
+++ b/lib/cos/src/wait.c
@@ -1,3 +1,19 @@
+/*
+ * wait.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 #include <sys/wait.h>

--- a/lib/cos/src/write.c
+++ b/lib/cos/src/write.c
@@ -1,3 +1,19 @@
+/*
+ * write.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <arch/x86_64-cos/syscalls.h>
 #include <arch/x86_64-cos/unistd.h>
 

--- a/user/cosh/include/builtin.h
+++ b/user/cosh/include/builtin.h
@@ -1,3 +1,19 @@
+/*
+ * builtin.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/user/cosh/include/dispatch.h
+++ b/user/cosh/include/dispatch.h
@@ -1,3 +1,19 @@
+/*
+ * dispatch.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/user/cosh/include/gen_argv.h
+++ b/user/cosh/include/gen_argv.h
@@ -1,3 +1,19 @@
+/*
+ * gen_argv.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/user/cosh/include/repl.h
+++ b/user/cosh/include/repl.h
@@ -1,3 +1,19 @@
+/*
+ * repl.h
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 int run_line (char* line);

--- a/user/cosh/src/builtin/chdir.c
+++ b/user/cosh/src/builtin/chdir.c
@@ -1,3 +1,19 @@
+/*
+ * chdir.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <unistd.h>
 

--- a/user/cosh/src/builtin/clear.c
+++ b/user/cosh/src/builtin/clear.c
@@ -1,3 +1,19 @@
+/*
+ * clear.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <stdio.h>
 

--- a/user/cosh/src/builtin/dispatch_builtin.c
+++ b/user/cosh/src/builtin/dispatch_builtin.c
@@ -1,3 +1,19 @@
+/*
+ * dispatch_builtin.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <string.h>
 

--- a/user/cosh/src/builtin/echo.c
+++ b/user/cosh/src/builtin/echo.c
@@ -1,3 +1,19 @@
+/*
+ * echo.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <stdio.h>
 

--- a/user/cosh/src/builtin/eval.c
+++ b/user/cosh/src/builtin/eval.c
@@ -1,3 +1,19 @@
+/*
+ * eval.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <repl.h>
 #include <stdlib.h>

--- a/user/cosh/src/builtin/exit.c
+++ b/user/cosh/src/builtin/exit.c
@@ -1,3 +1,19 @@
+/*
+ * exit.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/user/cosh/src/builtin/getpid.c
+++ b/user/cosh/src/builtin/getpid.c
@@ -1,3 +1,19 @@
+/*
+ * getpid.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/user/cosh/src/builtin/ls.c
+++ b/user/cosh/src/builtin/ls.c
@@ -1,3 +1,19 @@
+/*
+ * ls.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <dirent.h>
 #include <stdio.h>

--- a/user/cosh/src/builtin/mkdir.c
+++ b/user/cosh/src/builtin/mkdir.c
@@ -1,3 +1,19 @@
+/*
+ * mkdir.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <stdio.h>
 #include <sys/stat.h>

--- a/user/cosh/src/builtin/pwd.c
+++ b/user/cosh/src/builtin/pwd.c
@@ -1,3 +1,19 @@
+/*
+ * pwd.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/user/cosh/src/builtin/source.c
+++ b/user/cosh/src/builtin/source.c
@@ -1,3 +1,19 @@
+/*
+ * source.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <repl.h>
 #include <stdio.h>

--- a/user/cosh/src/builtin/stat.c
+++ b/user/cosh/src/builtin/stat.c
@@ -1,3 +1,19 @@
+/*
+ * stat.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <stdio.h>
 #include <sys/stat.h>

--- a/user/cosh/src/builtin/test.c
+++ b/user/cosh/src/builtin/test.c
@@ -1,3 +1,19 @@
+/*
+ * test.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <stdlib.h>
 #include <string.h>

--- a/user/cosh/src/builtin/touch.c
+++ b/user/cosh/src/builtin/touch.c
@@ -1,3 +1,19 @@
+/*
+ * touch.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/user/cosh/src/dispatch.c
+++ b/user/cosh/src/dispatch.c
@@ -1,3 +1,19 @@
+/*
+ * dispatch.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <dispatch.h>
 #include <stdio.h>

--- a/user/cosh/src/gen_argv.c
+++ b/user/cosh/src/gen_argv.c
@@ -1,3 +1,19 @@
+/*
+ * gen_argv.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <ctype.h>
 #include <gen_argv.h>
 #include <stdint.h>

--- a/user/cosh/src/main.c
+++ b/user/cosh/src/main.c
@@ -1,3 +1,19 @@
+/*
+ * main.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <builtin.h>
 #include <repl.h>
 #include <stdlib.h>

--- a/user/cosh/src/repl_main.c
+++ b/user/cosh/src/repl_main.c
@@ -1,3 +1,19 @@
+/*
+ * repl_main.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <dispatch.h>
 #include <gen_argv.h>
 #include <repl.h>

--- a/user/hello/hello.c
+++ b/user/hello/hello.c
@@ -1,3 +1,19 @@
+/*
+ * hello.c
+ * Copyright (C) 2026  Aditya Kumar
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Adds the GPLv2 license and marks all kernel source files under it.

- Why GPLv2? Mostly following Linux's lead here on kernel licenses. It's flexible enough to help the OS be used if it ever needs to be, but also copyleft (personal preference).
- Why not BSD/MIT? I want COS to remain open in whichever forms it takes))
- Why license it at all? By default, code is all rights reserved, and legally nobody can use it even if they wanted to. With a license there is some scope for other people to legally do things with/to this code ;)